### PR TITLE
feat: configure Vercel deployment and update environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ npm-debug.log*
 # Codex — local-only overrides (personal model preferences, user-specific config)
 # .codex/config.toml and .agents/ are committed (shared project config)
 .codex/config.local.toml
+.vercel

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -19,6 +19,9 @@ import devRoutes from "./routes/dev.routes";
 
 const app = express();
 
+// Trust proxy headers from Vercel/reverse proxies
+app.set("trust proxy", 1);
+
 // ---------------------------------------------------------------------------
 // Global middleware
 // ---------------------------------------------------------------------------

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 dotenv.config();
 
 const envSchema = z.object({
-  MONGODB_URI: z.string().min(1, "MONGODB_URI is required").url("MONGODB_URI must be a valid URI"),
+  MONGODB_URI: z.string().min(1, "MONGODB_URI is required"),
   JWT_SECRET: z.string().min(32, "JWT_SECRET must be at least 32 characters"),
   JWT_REFRESH_SECRET: z.string().min(32, "JWT_REFRESH_SECRET must be at least 32 characters"),
   API_PORT: z.coerce.number().int().positive().default(4000),

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "multer": "^1.4.5-lts.1",
         "papaparse": "^5.4.1",
         "swagger-jsdoc": "^6.2.8",
-        "swagger-ui-express": "^5.0.1",
         "zod": "^3.23.0"
       },
       "devDependencies": {
@@ -47,7 +46,6 @@
         "@types/multer": "^1.4.11",
         "@types/papaparse": "^5.3.14",
         "@types/swagger-jsdoc": "^6.0.4",
-        "@types/swagger-ui-express": "^4.1.6",
         "mongodb-memory-server": "^10.0.0",
         "tsx": "^4.16.0",
         "typescript": "^5.5.0",
@@ -3439,13 +3437,6 @@
         "win32"
       ]
     },
-    "node_modules/@scarf/scarf": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
-      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -3985,17 +3976,6 @@
       "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/swagger-ui-express": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
-      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*",
-        "@types/serve-static": "*"
-      }
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -8529,30 +8509,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/swagger-ui-dist": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.0.tgz",
-      "integrity": "sha512-nKZB0OuDvacB0s/lC2gbge+RigYvGRGpLLMWMFxaTUwfM+CfndVk9Th2IaTinqXiz6Mn26GK2zriCpv6/+5m3Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@scarf/scarf": "=1.4.0"
-      }
-    },
-    "node_modules/swagger-ui-express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
-      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
-      "license": "MIT",
-      "dependencies": {
-        "swagger-ui-dist": ">=5.0.0"
-      },
-      "engines": {
-        "node": ">= v0.10.32"
-      },
-      "peerDependencies": {
-        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-tree": {

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -2,9 +2,11 @@
   "name": "@wealthwise/shared-types",
   "version": "1.0.0",
   "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
+    "prepare": "tsc",
+    "build": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "strict": true,
     "declaration": true,
     "declarationMap": true,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "apps/api/src/index.ts",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "apps/api/src/index.ts" }
+  ]
+}


### PR DESCRIPTION
This pull request introduces several updates to improve deployment compatibility, environment configuration, and package build processes. The main focus is on preparing the `@wealthwise/shared-types` package for distribution, updating environment validation, and adding configuration for deployment on Vercel.

### Deployment and Proxy Configuration

* Added `vercel.json` to configure the API for deployment on Vercel, specifying build instructions and routing for the API entry point.
* Enabled trust for proxy headers in Express by setting `app.set("trust proxy", 1)` in `apps/api/src/app.ts`, which is necessary for correct client IP handling when behind Vercel or other reverse proxies.

### Environment Validation

* Relaxed validation for `MONGODB_URI` in `apps/api/src/config/env.ts` by removing the strict URL check, allowing for more flexible connection string formats.

### Package Build and Distribution

* Updated `packages/shared-types/package.json` to use the compiled output in `dist` for both `main` and `types` fields, and added build scripts (`prepare`, `build`) for TypeScript compilation.
* Changed TypeScript configuration in `packages/shared-types/tsconfig.json` to use CommonJS modules and Node resolution for better compatibility with Node.js environments.