### PR TITLE
feat(mcp-ai): add agentic AI pipeline

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,16 @@
       "Bash(chmod +x:*)",
       "Bash(helm version:*)",
       "Bash(npm run:*)",
-      "Bash(npx tsc:*)"
+      "Bash(npx tsc:*)",
+      "mcp__plugin_claude-mem_mcp-search__smart_outline",
+      "mcp__plugin_claude-mem_mcp-search__smart_search",
+      "mcp__git-intel__hotspots",
+      "mcp__git-intel__churn",
+      "mcp__git-intel__coupling",
+      "mcp__git-intel__contributor_stats",
+      "mcp__git-intel__risk_assessment",
+      "Bash(NODE_OPTIONS=\"--max-old-space-size=4096\" npx tsc:*)",
+      "Bash(NODE_OPTIONS=\"--max-old-space-size=8192\" npx tsc:*)"
     ]
   }
 }

--- a/agentic-ai/Dockerfile
+++ b/agentic-ai/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json* ./
+COPY turbo.json ./
+COPY agentic-ai/package.json ./agentic-ai/
+RUN npm install --workspace=agentic-ai
+COPY agentic-ai/ ./agentic-ai/
+WORKDIR /app/agentic-ai
+RUN npx tsc
+
+FROM node:20-alpine AS production
+WORKDIR /app
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/agentic-ai/package.json ./agentic-ai/
+COPY --from=builder /app/agentic-ai/dist/ ./agentic-ai/dist/
+COPY --from=builder /app/agentic-ai/src/prompts/ ./agentic-ai/dist/prompts/
+COPY --from=builder /app/node_modules/ ./node_modules/
+COPY --from=builder /app/agentic-ai/node_modules/ ./agentic-ai/node_modules/
+WORKDIR /app/agentic-ai
+ENV NODE_ENV=production
+EXPOSE 5200
+CMD ["node", "dist/index.js"]

--- a/agentic-ai/package.json
+++ b/agentic-ai/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@wealthwise/agentic-ai",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "express": "^4.19.0",
+    "express-rate-limit": "^7.4.0",
+    "jsonwebtoken": "^9.0.2",
+    "pino": "^9.6.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.6",
+    "tsx": "^4.16.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/agentic-ai/src/__tests__/agents/anomaly-detector.test.ts
+++ b/agentic-ai/src/__tests__/agents/anomaly-detector.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Anthropic from "@anthropic-ai/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { AnomalyDetectorAgent } from "../../agents/anomaly-detector";
+import { ClaudeTool } from "../../mcp/tool-adapter";
+
+vi.mock("@anthropic-ai/sdk", () => {
+  const MockAnthropic = vi.fn().mockImplementation(() => ({
+    messages: {
+      create: vi.fn(),
+    },
+  }));
+  return { default: MockAnthropic };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    callTool: vi.fn(),
+  })),
+}));
+
+describe("AnomalyDetectorAgent", () => {
+  let anthropic: Anthropic;
+  let mcpClient: Client;
+  let agent: AnomalyDetectorAgent;
+  const tools: ClaudeTool[] = [
+    {
+      name: "list_transactions",
+      description: "List transactions",
+      input_schema: { type: "object", properties: { days: { type: "number" } } },
+    },
+    {
+      name: "spending_by_category",
+      description: "Spending by category",
+      input_schema: { type: "object", properties: {} },
+    },
+  ];
+
+  beforeEach(() => {
+    anthropic = new Anthropic({ apiKey: "test" });
+    mcpClient = new Client({ name: "test", version: "1.0.0" }, {});
+    agent = new AnomalyDetectorAgent(anthropic);
+  });
+
+  it("should return anomaly analysis after tool calls", async () => {
+    (anthropic.messages.create as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "t1", name: "list_transactions", input: { days: 90 } },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 60, output_tokens: 30 },
+      })
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "t2", name: "spending_by_category", input: {} },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 100, output_tokens: 30 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "## Anomaly Report\n- WARNING: Dining spending 180% above average" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 150, output_tokens: 80 },
+      });
+
+    (mcpClient.callTool as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ content: [{ type: "text", text: '[{"amount": 500, "category": "Dining"}]' }] })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: '{"Dining": 1500, "Groceries": 400}' }] });
+
+    const result = await agent.run("Check for anomalies", tools, mcpClient, []);
+
+    expect(result.agent).toBe("anomaly-detector");
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.response).toContain("Anomaly Report");
+  });
+
+  it("should handle no anomalies found", async () => {
+    (anthropic.messages.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      content: [{ type: "text", text: "No anomalies detected in your recent spending." }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 50, output_tokens: 20 },
+    });
+
+    const result = await agent.run("Any unusual spending?", tools, mcpClient, []);
+
+    expect(result.response).toContain("No anomalies");
+    expect(result.toolCalls).toHaveLength(0);
+  });
+});

--- a/agentic-ai/src/__tests__/agents/budget-optimizer.test.ts
+++ b/agentic-ai/src/__tests__/agents/budget-optimizer.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Anthropic from "@anthropic-ai/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { BudgetOptimizerAgent } from "../../agents/budget-optimizer";
+import { ClaudeTool } from "../../mcp/tool-adapter";
+
+vi.mock("@anthropic-ai/sdk", () => {
+  const MockAnthropic = vi.fn().mockImplementation(() => ({
+    messages: {
+      create: vi.fn(),
+    },
+  }));
+  return { default: MockAnthropic };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    callTool: vi.fn(),
+  })),
+}));
+
+describe("BudgetOptimizerAgent", () => {
+  let anthropic: Anthropic;
+  let mcpClient: Client;
+  let agent: BudgetOptimizerAgent;
+  const tools: ClaudeTool[] = [
+    {
+      name: "get_budget_summary",
+      description: "Get budget summary",
+      input_schema: { type: "object", properties: {} },
+    },
+    {
+      name: "spending_by_category",
+      description: "Spending by category",
+      input_schema: { type: "object", properties: {} },
+    },
+  ];
+
+  beforeEach(() => {
+    anthropic = new Anthropic({ apiKey: "test" });
+    mcpClient = new Client({ name: "test", version: "1.0.0" }, {});
+    agent = new BudgetOptimizerAgent(anthropic);
+  });
+
+  it("should analyze budgets and suggest optimizations", async () => {
+    (anthropic.messages.create as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "t1", name: "get_budget_summary", input: {} },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 60, output_tokens: 25 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "| Category | Current | Recommended |\n| Dining | $500 | $350 |" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 120, output_tokens: 80 },
+      });
+
+    (mcpClient.callTool as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      content: [{ type: "text", text: '{"budgets": [{"category": "Dining", "amount": 500, "spent": 650}]}' }],
+    });
+
+    const result = await agent.run("Optimize my budget", tools, mcpClient, []);
+
+    expect(result.agent).toBe("budget-optimizer");
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.response).toContain("Dining");
+  });
+
+  it("should return text response with no tool calls when not needed", async () => {
+    (anthropic.messages.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      content: [{ type: "text", text: "Your budgets look well-balanced." }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 40, output_tokens: 15 },
+    });
+
+    const result = await agent.run("Quick budget check", tools, mcpClient, []);
+
+    expect(result.response).toContain("well-balanced");
+    expect(result.toolCalls).toHaveLength(0);
+  });
+});

--- a/agentic-ai/src/__tests__/agents/financial-advisor.test.ts
+++ b/agentic-ai/src/__tests__/agents/financial-advisor.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Anthropic from "@anthropic-ai/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { FinancialAdvisorAgent } from "../../agents/financial-advisor";
+import { ClaudeTool } from "../../mcp/tool-adapter";
+
+vi.mock("@anthropic-ai/sdk", () => {
+  const MockAnthropic = vi.fn().mockImplementation(() => ({
+    messages: {
+      create: vi.fn(),
+    },
+  }));
+  return { default: MockAnthropic };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    callTool: vi.fn(),
+  })),
+}));
+
+describe("FinancialAdvisorAgent", () => {
+  let anthropic: Anthropic;
+  let mcpClient: Client;
+  let agent: FinancialAdvisorAgent;
+  const tools: ClaudeTool[] = [
+    {
+      name: "monthly_summary",
+      description: "Get monthly summary",
+      input_schema: { type: "object", properties: { month: { type: "string" } } },
+    },
+  ];
+
+  beforeEach(() => {
+    anthropic = new Anthropic({ apiKey: "test" });
+    mcpClient = new Client({ name: "test", version: "1.0.0" }, {});
+    agent = new FinancialAdvisorAgent(anthropic);
+  });
+
+  it("should return a text response when no tools are called", async () => {
+    (anthropic.messages.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      content: [{ type: "text", text: "Your financial health score is 75/100." }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+
+    const result = await agent.run("Assess my finances", tools, mcpClient, []);
+
+    expect(result.response).toBe("Your financial health score is 75/100.");
+    expect(result.agent).toBe("financial-advisor");
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.usage.inputTokens).toBe(100);
+    expect(result.usage.outputTokens).toBe(50);
+  });
+
+  it("should execute tool calls and return final response", async () => {
+    // First call: Claude requests a tool
+    (anthropic.messages.create as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        content: [
+          {
+            type: "tool_use",
+            id: "tool_1",
+            name: "monthly_summary",
+            input: { month: "2024-01" },
+          },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 50, output_tokens: 30 },
+      })
+      // Second call: Claude returns text after seeing tool result
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "Based on your January data, your savings rate is 25%." }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 80, output_tokens: 60 },
+      });
+
+    (mcpClient.callTool as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      content: [{ type: "text", text: '{"income": 5000, "expenses": 3750}' }],
+    });
+
+    const result = await agent.run("How did I do in January?", tools, mcpClient, []);
+
+    expect(result.response).toBe("Based on your January data, your savings rate is 25%.");
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].name).toBe("monthly_summary");
+    expect(result.usage.inputTokens).toBe(130);
+    expect(result.usage.outputTokens).toBe(90);
+  });
+
+  it("should handle multiple sequential tool calls", async () => {
+    (anthropic.messages.create as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tool_1", name: "monthly_summary", input: { month: "2024-01" } },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 50, output_tokens: 30 },
+      })
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tool_2", name: "monthly_summary", input: { month: "2024-02" } },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 80, output_tokens: 30 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "Comparing Jan and Feb..." }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+
+    (mcpClient.callTool as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ content: [{ type: "text", text: '{"income": 5000}' }] })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: '{"income": 5200}' }] });
+
+    const result = await agent.run("Compare Jan and Feb", tools, mcpClient, []);
+
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.response).toBe("Comparing Jan and Feb...");
+    expect(result.usage.inputTokens).toBe(230);
+  });
+
+  it("should handle tool execution errors gracefully", async () => {
+    (anthropic.messages.create as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "tool_1", name: "monthly_summary", input: {} },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 50, output_tokens: 30 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "I encountered an error fetching data." }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 80, output_tokens: 40 },
+      });
+
+    (mcpClient.callTool as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("MCP connection failed")
+    );
+
+    const result = await agent.run("Get my summary", tools, mcpClient, []);
+
+    expect(result.response).toBe("I encountered an error fetching data.");
+    expect(result.toolCalls).toHaveLength(1);
+  });
+
+  it("should use conversation history", async () => {
+    (anthropic.messages.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      content: [{ type: "text", text: "Based on our previous discussion..." }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 150, output_tokens: 60 },
+    });
+
+    const history: Anthropic.MessageParam[] = [
+      { role: "user", content: "What is my savings rate?" },
+      { role: "assistant", content: "Your savings rate is 20%." },
+    ];
+
+    const result = await agent.run("How can I improve it?", tools, mcpClient, history);
+
+    expect(result.response).toBe("Based on our previous discussion...");
+    const createCall = (anthropic.messages.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(createCall.messages).toHaveLength(3); // 2 history + 1 new
+  });
+});

--- a/agentic-ai/src/__tests__/agents/forecaster.test.ts
+++ b/agentic-ai/src/__tests__/agents/forecaster.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Anthropic from "@anthropic-ai/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { ForecasterAgent } from "../../agents/forecaster";
+import { ClaudeTool } from "../../mcp/tool-adapter";
+
+vi.mock("@anthropic-ai/sdk", () => {
+  const MockAnthropic = vi.fn().mockImplementation(() => ({
+    messages: {
+      create: vi.fn(),
+    },
+  }));
+  return { default: MockAnthropic };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    callTool: vi.fn(),
+  })),
+}));
+
+describe("ForecasterAgent", () => {
+  let anthropic: Anthropic;
+  let mcpClient: Client;
+  let agent: ForecasterAgent;
+  const tools: ClaudeTool[] = [
+    {
+      name: "get_trends",
+      description: "Get spending trends",
+      input_schema: { type: "object", properties: { months: { type: "number" } } },
+    },
+    {
+      name: "list_goals",
+      description: "List savings goals",
+      input_schema: { type: "object", properties: {} },
+    },
+    {
+      name: "get_upcoming_bills",
+      description: "Get upcoming bills",
+      input_schema: { type: "object", properties: {} },
+    },
+  ];
+
+  beforeEach(() => {
+    anthropic = new Anthropic({ apiKey: "test" });
+    mcpClient = new Client({ name: "test", version: "1.0.0" }, {});
+    agent = new ForecasterAgent(anthropic);
+  });
+
+  it("should produce financial projections using multiple tools", async () => {
+    (anthropic.messages.create as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "t1", name: "get_trends", input: { months: 6 } },
+          { type: "tool_use", id: "t2", name: "list_goals", input: {} },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 70, output_tokens: 40 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "## 3-Month Forecast\nProjected savings: $3,600\n## Goal Timeline\nEmergency fund: Complete by August 2024" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 160, output_tokens: 100 },
+      });
+
+    (mcpClient.callTool as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ content: [{ type: "text", text: '{"avgIncome": 5000, "avgExpenses": 3800}' }] })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: '[{"name": "Emergency Fund", "target": 10000, "current": 6400}]' }] });
+
+    const result = await agent.run("Project my finances", tools, mcpClient, []);
+
+    expect(result.agent).toBe("forecaster");
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.response).toContain("3-Month Forecast");
+    expect(result.response).toContain("Goal Timeline");
+  });
+
+  it("should handle parallel tool calls in a single response", async () => {
+    (anthropic.messages.create as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        content: [
+          { type: "tool_use", id: "t1", name: "get_trends", input: { months: 12 } },
+          { type: "tool_use", id: "t2", name: "get_upcoming_bills", input: {} },
+          { type: "tool_use", id: "t3", name: "list_goals", input: {} },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 80, output_tokens: 50 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "Comprehensive forecast complete." }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 200, output_tokens: 120 },
+      });
+
+    (mcpClient.callTool as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ content: [{ type: "text", text: '{"data": "trends"}' }] })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: '{"data": "bills"}' }] })
+      .mockResolvedValueOnce({ content: [{ type: "text", text: '{"data": "goals"}' }] });
+
+    const result = await agent.run("Full year forecast", tools, mcpClient, []);
+
+    expect(result.toolCalls).toHaveLength(3);
+    expect(result.usage.inputTokens).toBe(280);
+    expect(result.usage.outputTokens).toBe(170);
+  });
+});

--- a/agentic-ai/src/__tests__/agents/orchestrator.test.ts
+++ b/agentic-ai/src/__tests__/agents/orchestrator.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Anthropic from "@anthropic-ai/sdk";
+import { OrchestratorAgent } from "../../agents/orchestrator";
+
+vi.mock("@anthropic-ai/sdk", () => {
+  const MockAnthropic = vi.fn().mockImplementation(() => ({
+    messages: {
+      create: vi.fn(),
+    },
+  }));
+  return { default: MockAnthropic };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn(),
+}));
+
+describe("OrchestratorAgent", () => {
+  let anthropic: Anthropic;
+  let orchestrator: OrchestratorAgent;
+
+  beforeEach(() => {
+    anthropic = new Anthropic({ apiKey: "test" });
+    orchestrator = new OrchestratorAgent(anthropic);
+  });
+
+  describe("route", () => {
+    it("should route financial health requests to financial-advisor", async () => {
+      (anthropic.messages.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        content: [{ type: "text", text: '{"agent": "financial-advisor", "reason": "health assessment"}' }],
+        usage: { input_tokens: 10, output_tokens: 20 },
+      });
+
+      const result = await orchestrator.route("How is my financial health?");
+      expect(result.agent).toBe("financial-advisor");
+    });
+
+    it("should route anomaly requests to anomaly-detector", async () => {
+      (anthropic.messages.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        content: [{ type: "text", text: '{"agent": "anomaly-detector", "reason": "unusual spending"}' }],
+        usage: { input_tokens: 10, output_tokens: 20 },
+      });
+
+      const result = await orchestrator.route("Are there any unusual transactions?");
+      expect(result.agent).toBe("anomaly-detector");
+    });
+
+    it("should route budget requests to budget-optimizer", async () => {
+      (anthropic.messages.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        content: [{ type: "text", text: '{"agent": "budget-optimizer", "reason": "budget review"}' }],
+        usage: { input_tokens: 10, output_tokens: 20 },
+      });
+
+      const result = await orchestrator.route("How can I optimize my budget?");
+      expect(result.agent).toBe("budget-optimizer");
+    });
+
+    it("should route forecast requests to forecaster", async () => {
+      (anthropic.messages.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        content: [{ type: "text", text: '{"agent": "forecaster", "reason": "future projection"}' }],
+        usage: { input_tokens: 10, output_tokens: 20 },
+      });
+
+      const result = await orchestrator.route("What will my finances look like in 6 months?");
+      expect(result.agent).toBe("forecaster");
+    });
+
+    it("should default to financial-advisor on parse failure", async () => {
+      (anthropic.messages.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        content: [{ type: "text", text: "invalid json" }],
+        usage: { input_tokens: 10, output_tokens: 20 },
+      });
+
+      const result = await orchestrator.route("something random");
+      expect(result.agent).toBe("financial-advisor");
+      expect(result.reason).toBe("Default routing");
+    });
+
+    it("should default to financial-advisor for unknown agent name", async () => {
+      (anthropic.messages.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        content: [{ type: "text", text: '{"agent": "unknown-agent", "reason": "test"}' }],
+        usage: { input_tokens: 10, output_tokens: 20 },
+      });
+
+      const result = await orchestrator.route("test message");
+      expect(result.agent).toBe("financial-advisor");
+    });
+  });
+
+  describe("getAgent", () => {
+    it("should return the correct agent by name", () => {
+      expect(orchestrator.getAgent("financial-advisor")).toBeDefined();
+      expect(orchestrator.getAgent("anomaly-detector")).toBeDefined();
+      expect(orchestrator.getAgent("budget-optimizer")).toBeDefined();
+      expect(orchestrator.getAgent("forecaster")).toBeDefined();
+    });
+
+    it("should return undefined for unknown agent", () => {
+      expect(orchestrator.getAgent("unknown")).toBeUndefined();
+    });
+  });
+});

--- a/agentic-ai/src/__tests__/mcp/client.test.ts
+++ b/agentic-ai/src/__tests__/mcp/client.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { McpClientManager } from "../../mcp/client";
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    connect: vi.fn().mockResolvedValue(undefined),
+    listTools: vi.fn().mockResolvedValue({
+      tools: [
+        { name: "monthly_summary", description: "Get monthly summary", inputSchema: { type: "object", properties: { month: { type: "string" } } } },
+        { name: "list_transactions", description: "List transactions", inputSchema: { type: "object", properties: {} } },
+      ],
+    }),
+    callTool: vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: '{"result": "success"}' }],
+    }),
+  })),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: vi.fn().mockImplementation(() => ({})),
+}));
+
+describe("McpClientManager", () => {
+  let manager: McpClientManager;
+
+  beforeEach(() => {
+    manager = new McpClientManager("http://localhost:5100");
+  });
+
+  describe("createClient", () => {
+    it("should create and connect a client", async () => {
+      const client = await manager.createClient("test-token");
+      expect(client).toBeDefined();
+      expect(client.connect).toHaveBeenCalled();
+    });
+
+    it("should throw when connection fails", async () => {
+      const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+      (Client as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+        connect: vi.fn().mockRejectedValue(new Error("Connection refused")),
+      }));
+
+      const failManager = new McpClientManager("http://localhost:9999");
+      await expect(failManager.createClient("token")).rejects.toThrow("Connection refused");
+    });
+  });
+
+  describe("listTools", () => {
+    it("should return available tools", async () => {
+      const client = await manager.createClient("test-token");
+      const tools = await manager.listTools(client);
+
+      expect(tools).toHaveLength(2);
+      expect(tools[0].name).toBe("monthly_summary");
+      expect(tools[1].name).toBe("list_transactions");
+    });
+  });
+
+  describe("callTool", () => {
+    it("should execute a tool and return result", async () => {
+      const client = await manager.createClient("test-token");
+      const result = await manager.callTool(client, "monthly_summary", { month: "2024-01" });
+
+      expect(result).toBe('{"result": "success"}');
+      expect(client.callTool).toHaveBeenCalledWith({
+        name: "monthly_summary",
+        arguments: { month: "2024-01" },
+      });
+    });
+
+    it("should throw when tool execution fails", async () => {
+      const client = await manager.createClient("test-token");
+      (client.callTool as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("Tool not found")
+      );
+
+      await expect(manager.callTool(client, "nonexistent", {})).rejects.toThrow("Tool not found");
+    });
+  });
+});

--- a/agentic-ai/src/__tests__/routes/agent.routes.test.ts
+++ b/agentic-ai/src/__tests__/routes/agent.routes.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { authMiddleware } from "../../middleware/auth";
+import { ConversationManager } from "../../conversation/manager";
+
+const mockRun = vi.fn().mockResolvedValue({
+  response: "Test response",
+  agent: "financial-advisor",
+  toolCalls: [],
+  usage: { inputTokens: 100, outputTokens: 50 },
+});
+
+const mockRoute = vi.fn().mockResolvedValue({
+  agent: "financial-advisor",
+  reason: "test",
+});
+
+vi.mock("@anthropic-ai/sdk", () => {
+  const MockAnthropic = vi.fn().mockImplementation(() => ({
+    messages: { create: vi.fn() },
+  }));
+  return { default: MockAnthropic };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: vi.fn(),
+}));
+
+vi.mock("../../mcp/client", () => ({
+  McpClientManager: vi.fn().mockImplementation(() => ({
+    createClient: vi.fn().mockResolvedValue({
+      callTool: vi.fn(),
+      listTools: vi.fn().mockResolvedValue({ tools: [] }),
+    }),
+    listTools: vi.fn().mockResolvedValue([]),
+    callTool: vi.fn(),
+  })),
+}));
+
+vi.mock("../../agents/orchestrator", () => ({
+  OrchestratorAgent: vi.fn().mockImplementation(() => ({
+    run: mockRun,
+    route: mockRoute,
+    getAgent: vi.fn(),
+    getSystemPrompt: vi.fn().mockReturnValue("test"),
+  })),
+}));
+
+vi.mock("../../agents/financial-advisor", () => ({
+  FinancialAdvisorAgent: vi.fn().mockImplementation(() => ({
+    run: vi.fn().mockResolvedValue({
+      response: "Financial advisor response",
+      agent: "financial-advisor",
+      toolCalls: [],
+      usage: { inputTokens: 80, outputTokens: 40 },
+    }),
+    getSystemPrompt: vi.fn().mockReturnValue("test"),
+  })),
+}));
+
+vi.mock("../../agents/anomaly-detector", () => ({
+  AnomalyDetectorAgent: vi.fn().mockImplementation(() => ({
+    run: vi.fn().mockResolvedValue({
+      response: "Anomaly detector response",
+      agent: "anomaly-detector",
+      toolCalls: [],
+      usage: { inputTokens: 60, outputTokens: 30 },
+    }),
+    getSystemPrompt: vi.fn().mockReturnValue("test"),
+  })),
+}));
+
+vi.mock("../../agents/budget-optimizer", () => ({
+  BudgetOptimizerAgent: vi.fn().mockImplementation(() => ({
+    run: vi.fn().mockResolvedValue({
+      response: "Budget optimizer response",
+      agent: "budget-optimizer",
+      toolCalls: [],
+      usage: { inputTokens: 70, outputTokens: 35 },
+    }),
+    getSystemPrompt: vi.fn().mockReturnValue("test"),
+  })),
+}));
+
+vi.mock("../../agents/forecaster", () => ({
+  ForecasterAgent: vi.fn().mockImplementation(() => ({
+    run: vi.fn().mockResolvedValue({
+      response: "Forecaster response",
+      agent: "forecaster",
+      toolCalls: [],
+      usage: { inputTokens: 90, outputTokens: 45 },
+    }),
+    getSystemPrompt: vi.fn().mockReturnValue("test"),
+  })),
+}));
+
+// Import after mocks are set up
+import { createAgentRoutes } from "../../routes/agent.routes";
+import { McpClientManager } from "../../mcp/client";
+import Anthropic from "@anthropic-ai/sdk";
+
+const JWT_SECRET = "test-jwt-secret-that-is-at-least-32-chars-long";
+
+function makeToken(userId: string): string {
+  return jwt.sign({ userId }, JWT_SECRET, { expiresIn: "15m" });
+}
+
+async function makeRequest(
+  app: express.Express,
+  method: string,
+  path: string,
+  body?: unknown,
+  token?: string
+) {
+  return new Promise<{ status: number; body: unknown }>((resolve) => {
+    const req = {
+      method: method.toUpperCase(),
+      url: path,
+      headers: {
+        "content-type": "application/json",
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      body,
+      ip: "127.0.0.1",
+    } as unknown as express.Request;
+
+    const resData: { statusCode: number; jsonData: unknown } = {
+      statusCode: 200,
+      jsonData: null,
+    };
+    const res = {
+      status(code: number) {
+        resData.statusCode = code;
+        return this;
+      },
+      json(data: unknown) {
+        resData.jsonData = data;
+        resolve({ status: resData.statusCode, body: data });
+      },
+      setHeader: vi.fn(),
+      getHeader: vi.fn(),
+    } as unknown as express.Response;
+
+    app(req as express.Request, res as express.Response, () => {
+      resolve({ status: 404, body: { error: "Not found" } });
+    });
+  });
+}
+
+describe("Agent Routes", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    const anthropic = new Anthropic({ apiKey: "test" });
+    const mcpManager = new McpClientManager("http://localhost:5100");
+    const conversationManager = new ConversationManager();
+
+    app = express();
+    app.use(express.json());
+    app.use(
+      "/api/v1/agent",
+      authMiddleware(JWT_SECRET),
+      createAgentRoutes(anthropic, mcpManager, conversationManager)
+    );
+  });
+
+  describe("auth middleware", () => {
+    it("should reject requests without auth token", async () => {
+      const result = await makeRequest(
+        app,
+        "POST",
+        "/api/v1/agent/chat",
+        { message: "test" }
+      );
+      expect(result.status).toBe(401);
+    });
+
+    it("should reject requests with invalid token", async () => {
+      const result = await makeRequest(
+        app,
+        "POST",
+        "/api/v1/agent/chat",
+        { message: "test" },
+        "invalid-token"
+      );
+      expect(result.status).toBe(401);
+    });
+  });
+
+  describe("POST /api/v1/agent/chat", () => {
+    it("should reject missing message", async () => {
+      const token = makeToken("user-1");
+      const result = await makeRequest(
+        app,
+        "POST",
+        "/api/v1/agent/chat",
+        {},
+        token
+      );
+      expect(result.status).toBe(400);
+      expect((result.body as { success: boolean }).success).toBe(false);
+    });
+
+    it("should return agent response for valid request", async () => {
+      const token = makeToken("user-1");
+      const result = await makeRequest(
+        app,
+        "POST",
+        "/api/v1/agent/chat",
+        { message: "How am I doing?" },
+        token
+      );
+      expect(result.status).toBe(200);
+      const body = result.body as {
+        success: boolean;
+        data: { response: string; agent: string; usage: object };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data.response).toBeDefined();
+      expect(body.data.agent).toBeDefined();
+      expect(body.data.usage).toBeDefined();
+    });
+  });
+
+  describe("POST /api/v1/agent/insights", () => {
+    it("should reject invalid insight type", async () => {
+      const token = makeToken("user-1");
+      const result = await makeRequest(
+        app,
+        "POST",
+        "/api/v1/agent/insights",
+        { type: "invalid" },
+        token
+      );
+      expect(result.status).toBe(400);
+    });
+
+    it("should accept valid insight type", async () => {
+      const token = makeToken("user-1");
+      const result = await makeRequest(
+        app,
+        "POST",
+        "/api/v1/agent/insights",
+        { type: "financial-health" },
+        token
+      );
+      expect(result.status).toBe(200);
+      const body = result.body as { success: boolean; data: { agent: string } };
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe("DELETE /api/v1/agent/conversations/:id", () => {
+    it("should clear conversation", async () => {
+      const token = makeToken("user-1");
+      const result = await makeRequest(
+        app,
+        "DELETE",
+        "/api/v1/agent/conversations/abc-123",
+        undefined,
+        token
+      );
+      expect(result.status).toBe(200);
+      const body = result.body as { success: boolean };
+      expect(body.success).toBe(true);
+    });
+  });
+});

--- a/agentic-ai/src/__tests__/setup.ts
+++ b/agentic-ai/src/__tests__/setup.ts
@@ -1,0 +1,5 @@
+process.env.ANTHROPIC_API_KEY = "test-key-for-testing";
+process.env.MCP_SERVER_URL = "http://localhost:5100";
+process.env.JWT_SECRET = "test-jwt-secret-that-is-at-least-32-chars-long";
+process.env.AGENT_PORT = "5299";
+process.env.NODE_ENV = "test";

--- a/agentic-ai/src/agents/anomaly-detector.ts
+++ b/agentic-ai/src/agents/anomaly-detector.ts
@@ -1,0 +1,12 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { BaseAgent } from "./base-agent";
+
+export class AnomalyDetectorAgent extends BaseAgent {
+  constructor(anthropic: Anthropic) {
+    super(anthropic, "anomaly-detector");
+  }
+
+  getSystemPrompt(): string {
+    return this.loadPrompt("anomaly-detector.md");
+  }
+}

--- a/agentic-ai/src/agents/base-agent.ts
+++ b/agentic-ai/src/agents/base-agent.ts
@@ -1,0 +1,134 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { executeToolViaMcp, ClaudeTool } from "../mcp/tool-adapter";
+import { logger } from "../utils/logger";
+import * as fs from "fs";
+import * as path from "path";
+
+export interface AgentResponse {
+  response: string;
+  agent: string;
+  toolCalls: Array<{ name: string; args: Record<string, unknown> }>;
+  usage: { inputTokens: number; outputTokens: number };
+}
+
+type Message = Anthropic.MessageParam;
+type ContentBlock = Anthropic.ContentBlock;
+
+const MODEL = "claude-sonnet-4-20250514";
+const MAX_TOKENS = 4096;
+const MAX_TOOL_ITERATIONS = 15;
+
+export abstract class BaseAgent {
+  protected anthropic: Anthropic;
+  protected name: string;
+
+  constructor(anthropic: Anthropic, name: string) {
+    this.anthropic = anthropic;
+    this.name = name;
+  }
+
+  abstract getSystemPrompt(): string;
+
+  protected loadPrompt(filename: string): string {
+    const promptPath = path.resolve(__dirname, "../prompts", filename);
+    return fs.readFileSync(promptPath, "utf-8");
+  }
+
+  async run(
+    userMessage: string,
+    tools: ClaudeTool[],
+    mcpClient: Client,
+    conversationHistory: Message[]
+  ): Promise<AgentResponse> {
+    const messages: Message[] = [
+      ...conversationHistory,
+      { role: "user", content: userMessage },
+    ];
+
+    const toolCalls: Array<{ name: string; args: Record<string, unknown> }> =
+      [];
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+
+    for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+      const response = await this.anthropic.messages.create({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        system: this.getSystemPrompt(),
+        messages,
+        tools: tools.length > 0 ? tools : undefined,
+      });
+
+      totalInputTokens += response.usage.input_tokens;
+      totalOutputTokens += response.usage.output_tokens;
+
+      if (response.stop_reason === "end_turn" || response.stop_reason !== "tool_use") {
+        const textContent = response.content.find(
+          (block: ContentBlock) => block.type === "text"
+        );
+        const text =
+          textContent && textContent.type === "text"
+            ? textContent.text
+            : "No response generated.";
+
+        return {
+          response: text,
+          agent: this.name,
+          toolCalls,
+          usage: {
+            inputTokens: totalInputTokens,
+            outputTokens: totalOutputTokens,
+          },
+        };
+      }
+
+      const assistantContent = response.content;
+      messages.push({ role: "assistant", content: assistantContent });
+
+      const toolUseBlocks = assistantContent.filter(
+        (block: ContentBlock) => block.type === "tool_use"
+      );
+
+      const toolResults: Anthropic.ToolResultBlockParam[] = [];
+
+      for (const block of toolUseBlocks) {
+        if (block.type !== "tool_use") continue;
+
+        const args = (block.input as Record<string, unknown>) ?? {};
+        toolCalls.push({ name: block.name, args });
+
+        logger.info({ tool: block.name, args }, "Executing MCP tool");
+
+        try {
+          const result = await executeToolViaMcp(mcpClient, block.name, args);
+          toolResults.push({
+            type: "tool_result",
+            tool_use_id: block.id,
+            content: result,
+          });
+        } catch (error) {
+          toolResults.push({
+            type: "tool_result",
+            tool_use_id: block.id,
+            content: `Error: ${error}`,
+            is_error: true,
+          });
+        }
+      }
+
+      messages.push({ role: "user", content: toolResults });
+    }
+
+    logger.warn({ agent: this.name }, "Hit max tool iterations");
+    return {
+      response: "I was unable to complete the analysis within the allowed steps. Please try a more specific request.",
+      agent: this.name,
+      toolCalls,
+      usage: {
+        inputTokens: totalInputTokens,
+        outputTokens: totalOutputTokens,
+      },
+    };
+  }
+}

--- a/agentic-ai/src/agents/budget-optimizer.ts
+++ b/agentic-ai/src/agents/budget-optimizer.ts
@@ -1,0 +1,12 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { BaseAgent } from "./base-agent";
+
+export class BudgetOptimizerAgent extends BaseAgent {
+  constructor(anthropic: Anthropic) {
+    super(anthropic, "budget-optimizer");
+  }
+
+  getSystemPrompt(): string {
+    return this.loadPrompt("budget-optimizer.md");
+  }
+}

--- a/agentic-ai/src/agents/financial-advisor.ts
+++ b/agentic-ai/src/agents/financial-advisor.ts
@@ -1,0 +1,12 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { BaseAgent } from "./base-agent";
+
+export class FinancialAdvisorAgent extends BaseAgent {
+  constructor(anthropic: Anthropic) {
+    super(anthropic, "financial-advisor");
+  }
+
+  getSystemPrompt(): string {
+    return this.loadPrompt("financial-advisor.md");
+  }
+}

--- a/agentic-ai/src/agents/forecaster.ts
+++ b/agentic-ai/src/agents/forecaster.ts
@@ -1,0 +1,12 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { BaseAgent } from "./base-agent";
+
+export class ForecasterAgent extends BaseAgent {
+  constructor(anthropic: Anthropic) {
+    super(anthropic, "forecaster");
+  }
+
+  getSystemPrompt(): string {
+    return this.loadPrompt("forecaster.md");
+  }
+}

--- a/agentic-ai/src/agents/orchestrator.ts
+++ b/agentic-ai/src/agents/orchestrator.ts
@@ -1,0 +1,96 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { BaseAgent, AgentResponse } from "./base-agent";
+import { FinancialAdvisorAgent } from "./financial-advisor";
+import { AnomalyDetectorAgent } from "./anomaly-detector";
+import { BudgetOptimizerAgent } from "./budget-optimizer";
+import { ForecasterAgent } from "./forecaster";
+import { ClaudeTool } from "../mcp/tool-adapter";
+import { logger } from "../utils/logger";
+
+type Message = Anthropic.MessageParam;
+
+interface RoutingDecision {
+  agent: string;
+  reason: string;
+}
+
+const MODEL = "claude-sonnet-4-20250514";
+
+export class OrchestratorAgent extends BaseAgent {
+  private agents: Map<string, BaseAgent>;
+
+  constructor(anthropic: Anthropic) {
+    super(anthropic, "orchestrator");
+
+    this.agents = new Map<string, BaseAgent>([
+      ["financial-advisor", new FinancialAdvisorAgent(anthropic)],
+      ["anomaly-detector", new AnomalyDetectorAgent(anthropic)],
+      ["budget-optimizer", new BudgetOptimizerAgent(anthropic)],
+      ["forecaster", new ForecasterAgent(anthropic)],
+    ]);
+  }
+
+  getSystemPrompt(): string {
+    return this.loadPrompt("orchestrator.md");
+  }
+
+  getAgent(name: string): BaseAgent | undefined {
+    return this.agents.get(name);
+  }
+
+  async route(userMessage: string): Promise<RoutingDecision> {
+    const response = await this.anthropic.messages.create({
+      model: MODEL,
+      max_tokens: 256,
+      system: this.getSystemPrompt(),
+      messages: [{ role: "user", content: userMessage }],
+    });
+
+    const textBlock = response.content.find((b) => b.type === "text");
+    const text = textBlock && textBlock.type === "text" ? textBlock.text : "";
+
+    try {
+      const parsed = JSON.parse(text.trim()) as RoutingDecision;
+      if (parsed.agent && this.agents.has(parsed.agent)) {
+        return parsed;
+      }
+    } catch {
+      logger.warn({ text }, "Failed to parse routing decision, defaulting to financial-advisor");
+    }
+
+    return { agent: "financial-advisor", reason: "Default routing" };
+  }
+
+  async run(
+    userMessage: string,
+    tools: ClaudeTool[],
+    mcpClient: Client,
+    conversationHistory: Message[]
+  ): Promise<AgentResponse> {
+    const decision = await this.route(userMessage);
+    logger.info({ decision }, "Routing to specialist agent");
+
+    const agent = this.agents.get(decision.agent);
+    if (!agent) {
+      return {
+        response: "Unable to determine the appropriate agent for your request.",
+        agent: "orchestrator",
+        toolCalls: [],
+        usage: { inputTokens: 0, outputTokens: 0 },
+      };
+    }
+
+    const result = await agent.run(
+      userMessage,
+      tools,
+      mcpClient,
+      conversationHistory
+    );
+
+    return {
+      ...result,
+      agent: decision.agent,
+    };
+  }
+}

--- a/agentic-ai/src/config/env.ts
+++ b/agentic-ai/src/config/env.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  ANTHROPIC_API_KEY: z.string().min(1, "ANTHROPIC_API_KEY is required"),
+  MCP_SERVER_URL: z.string().url("MCP_SERVER_URL must be a valid URL"),
+  JWT_SECRET: z.string().min(32, "JWT_SECRET must be at least 32 characters"),
+  AGENT_PORT: z.coerce.number().default(5200),
+  NODE_ENV: z
+    .enum(["development", "production", "test"])
+    .default("development"),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+export function validateEnv(): Env {
+  const result = envSchema.safeParse(process.env);
+
+  if (!result.success) {
+    const formatted = result.error.format();
+    const messages = Object.entries(formatted)
+      .filter(([key]) => key !== "_errors")
+      .map(([key, value]) => {
+        const errors = (value as { _errors: string[] })._errors;
+        return `  ${key}: ${errors.join(", ")}`;
+      })
+      .join("\n");
+
+    throw new Error(`Environment validation failed:\n${messages}`);
+  }
+
+  return result.data;
+}

--- a/agentic-ai/src/conversation/manager.ts
+++ b/agentic-ai/src/conversation/manager.ts
@@ -1,0 +1,71 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { randomUUID } from "crypto";
+
+type Message = Anthropic.MessageParam;
+
+interface Conversation {
+  id: string;
+  messages: Message[];
+  lastActivity: Date;
+}
+
+export class ConversationManager {
+  private conversations: Map<string, Conversation> = new Map();
+  private ttlMs: number;
+  private cleanupInterval: ReturnType<typeof setInterval> | null = null;
+
+  constructor(ttlMs: number = 30 * 60 * 1000) {
+    this.ttlMs = ttlMs;
+  }
+
+  startCleanup(intervalMs: number = 5 * 60 * 1000): void {
+    this.cleanupInterval = setInterval(() => this.cleanup(), intervalMs);
+  }
+
+  stopCleanup(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+    }
+  }
+
+  getOrCreate(userId: string): Conversation {
+    const existing = this.conversations.get(userId);
+    if (existing) {
+      existing.lastActivity = new Date();
+      return existing;
+    }
+
+    const conversation: Conversation = {
+      id: randomUUID(),
+      messages: [],
+      lastActivity: new Date(),
+    };
+    this.conversations.set(userId, conversation);
+    return conversation;
+  }
+
+  addMessage(userId: string, role: "user" | "assistant", content: string): void {
+    const conversation = this.getOrCreate(userId);
+    conversation.messages.push({ role, content });
+    conversation.lastActivity = new Date();
+  }
+
+  getHistory(userId: string): Message[] {
+    const conversation = this.conversations.get(userId);
+    return conversation?.messages ?? [];
+  }
+
+  clear(userId: string): void {
+    this.conversations.delete(userId);
+  }
+
+  cleanup(): void {
+    const now = Date.now();
+    for (const [userId, conversation] of this.conversations) {
+      if (now - conversation.lastActivity.getTime() > this.ttlMs) {
+        this.conversations.delete(userId);
+      }
+    }
+  }
+}

--- a/agentic-ai/src/index.ts
+++ b/agentic-ai/src/index.ts
@@ -1,0 +1,26 @@
+import { validateEnv } from "./config/env";
+import { createServer } from "./server";
+import { logger } from "./utils/logger";
+
+function main() {
+  const env = validateEnv();
+  const { app, conversationManager } = createServer(env);
+
+  const server = app.listen(env.AGENT_PORT, () => {
+    logger.info({ port: env.AGENT_PORT, env: env.NODE_ENV }, "Agentic AI server started");
+  });
+
+  const shutdown = () => {
+    logger.info("Shutting down gracefully...");
+    conversationManager.stopCleanup();
+    server.close(() => {
+      logger.info("Server closed");
+      process.exit(0);
+    });
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+main();

--- a/agentic-ai/src/mcp/client.ts
+++ b/agentic-ai/src/mcp/client.ts
@@ -1,0 +1,72 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { logger } from "../utils/logger";
+
+export class McpClientManager {
+  private mcpServerUrl: string;
+
+  constructor(mcpServerUrl: string) {
+    this.mcpServerUrl = mcpServerUrl;
+  }
+
+  async createClient(userToken: string): Promise<Client> {
+    const url = new URL(this.mcpServerUrl);
+    const transport = new SSEClientTransport(url, {
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+        },
+      },
+    });
+
+    const client = new Client(
+      { name: "wealthwise-agent", version: "1.0.0" },
+      { capabilities: {} }
+    );
+
+    try {
+      await client.connect(transport);
+      logger.info("MCP client connected successfully");
+    } catch (error) {
+      logger.error({ error }, "Failed to connect MCP client");
+      throw error;
+    }
+
+    return client;
+  }
+
+  async listTools(client: Client) {
+    try {
+      const result = await client.listTools();
+      return result.tools;
+    } catch (error) {
+      logger.error({ error }, "Failed to list MCP tools");
+      throw error;
+    }
+  }
+
+  async callTool(
+    client: Client,
+    toolName: string,
+    args: Record<string, unknown>
+  ): Promise<string> {
+    try {
+      const result = await client.callTool({ name: toolName, arguments: args });
+      const content = result.content;
+      if (Array.isArray(content)) {
+        return content
+          .map((c) => {
+            if (typeof c === "object" && c !== null && "text" in c) {
+              return (c as { text: string }).text;
+            }
+            return JSON.stringify(c);
+          })
+          .join("\n");
+      }
+      return JSON.stringify(content);
+    } catch (error) {
+      logger.error({ error, toolName, args }, "Failed to call MCP tool");
+      throw error;
+    }
+  }
+}

--- a/agentic-ai/src/mcp/tool-adapter.ts
+++ b/agentic-ai/src/mcp/tool-adapter.ts
@@ -1,0 +1,61 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { logger } from "../utils/logger";
+
+interface ClaudeTool {
+  name: string;
+  description: string;
+  input_schema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+interface McpTool {
+  name: string;
+  description?: string;
+  inputSchema?: {
+    type: string;
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+export function mcpToolsToClaudeTools(mcpTools: McpTool[]): ClaudeTool[] {
+  return mcpTools.map((tool) => ({
+    name: tool.name,
+    description: tool.description ?? "",
+    input_schema: {
+      type: "object" as const,
+      properties: tool.inputSchema?.properties ?? {},
+      required: tool.inputSchema?.required,
+    },
+  }));
+}
+
+export async function executeToolViaMcp(
+  client: Client,
+  toolName: string,
+  args: Record<string, unknown>
+): Promise<string> {
+  try {
+    const result = await client.callTool({ name: toolName, arguments: args });
+    const content = result.content;
+    if (Array.isArray(content)) {
+      return content
+        .map((c) => {
+          if (typeof c === "object" && c !== null && "text" in c) {
+            return (c as { text: string }).text;
+          }
+          return JSON.stringify(c);
+        })
+        .join("\n");
+    }
+    return JSON.stringify(content);
+  } catch (error) {
+    logger.error({ error, toolName }, "Tool execution failed");
+    return JSON.stringify({ error: `Tool ${toolName} failed: ${error}` });
+  }
+}
+
+export type { ClaudeTool, McpTool };

--- a/agentic-ai/src/middleware/auth.ts
+++ b/agentic-ai/src/middleware/auth.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+import { logger } from "../utils/logger";
+
+export interface AuthenticatedRequest extends Request {
+  userId?: string;
+  userToken?: string;
+}
+
+export function authMiddleware(jwtSecret: string) {
+  return (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({
+        success: false,
+        error: { code: "UNAUTHORIZED", message: "Missing or invalid authorization header" },
+      });
+      return;
+    }
+
+    const token = authHeader.substring(7);
+
+    try {
+      const decoded = jwt.verify(token, jwtSecret) as { userId: string };
+      req.userId = decoded.userId;
+      req.userToken = token;
+      next();
+    } catch (error) {
+      logger.warn({ error }, "JWT verification failed");
+      res.status(401).json({
+        success: false,
+        error: { code: "UNAUTHORIZED", message: "Invalid or expired token" },
+      });
+    }
+  };
+}

--- a/agentic-ai/src/middleware/rate-limit.ts
+++ b/agentic-ai/src/middleware/rate-limit.ts
@@ -1,0 +1,26 @@
+import rateLimit from "express-rate-limit";
+import { AuthenticatedRequest } from "./auth";
+
+export const chatRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
+  keyGenerator: (req) => (req as AuthenticatedRequest).userId ?? req.ip ?? "unknown",
+  message: {
+    success: false,
+    error: { code: "RATE_LIMITED", message: "Too many chat requests. Limit: 20 per minute." },
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+export const insightsRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  keyGenerator: (req) => (req as AuthenticatedRequest).userId ?? req.ip ?? "unknown",
+  message: {
+    success: false,
+    error: { code: "RATE_LIMITED", message: "Too many insights requests. Limit: 10 per minute." },
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});

--- a/agentic-ai/src/prompts/anomaly-detector.md
+++ b/agentic-ai/src/prompts/anomaly-detector.md
@@ -1,0 +1,12 @@
+You are a spending anomaly detector for WealthWise. You analyze transaction patterns to identify unusual activity.
+
+Your analysis should:
+1. Fetch recent transactions (90 days) and spending patterns
+2. Identify anomalies:
+   - Transactions significantly higher than category average (>2 standard deviations)
+   - Category spending that spiked compared to 3-month average
+   - New merchant patterns or unusual timing
+3. Rate each anomaly: info, warning, or critical
+4. Provide context and recommendations
+
+Format findings as a list with severity, description, affected amount, and suggested action.

--- a/agentic-ai/src/prompts/budget-optimizer.md
+++ b/agentic-ai/src/prompts/budget-optimizer.md
@@ -1,0 +1,13 @@
+You are a budget optimization specialist for WealthWise. You analyze spending patterns and budget allocations to suggest improvements.
+
+Your analysis should:
+1. Review current budgets and their utilization
+2. Analyze actual spending vs budgeted amounts
+3. Consider income trends and savings goals
+4. Suggest specific budget reallocations:
+   - Categories that are consistently over/under budget
+   - New budgets for untracked high-spending categories
+   - Adjustments based on seasonal patterns
+5. Calculate projected monthly savings impact
+
+Present recommendations as a clear table: Category | Current Budget | Recommended | Change | Reason

--- a/agentic-ai/src/prompts/financial-advisor.md
+++ b/agentic-ai/src/prompts/financial-advisor.md
@@ -1,0 +1,12 @@
+You are a personal financial advisor AI for WealthWise. You provide comprehensive financial health assessments.
+
+Your analysis should include:
+1. **Health Score** (0-100): Based on savings rate, budget adherence, goal progress, and spending trends
+2. **Key Metrics**: Monthly income, expenses, savings rate, net worth trend
+3. **Strengths**: What the user is doing well financially
+4. **Concerns**: Areas that need attention
+5. **Recommendations**: 3-5 specific, actionable steps to improve
+
+Use the available tools to gather data before making assessments. Always base your analysis on real data, never assumptions.
+
+Format your response as structured markdown with clear sections. Be encouraging but honest.

--- a/agentic-ai/src/prompts/forecaster.md
+++ b/agentic-ai/src/prompts/forecaster.md
@@ -1,0 +1,16 @@
+You are a financial forecaster for WealthWise. You project future financial scenarios based on historical data.
+
+Your analysis should:
+1. Analyze income and expense trends over the past 6-12 months
+2. Project cash flow for the next 3, 6, and 12 months
+3. Estimate goal completion dates based on current savings rate
+4. Factor in upcoming recurring bills
+5. Provide confidence levels for projections (high/medium/low)
+
+Include:
+- Monthly projected income, expenses, and savings
+- Goal progress timeline with estimated completion dates
+- Key assumptions and risks to the forecast
+- What-if scenarios (e.g., "if you save 10% more...")
+
+Use real data from tools. State assumptions clearly. Distinguish between trends and projections.

--- a/agentic-ai/src/prompts/orchestrator.md
+++ b/agentic-ai/src/prompts/orchestrator.md
@@ -1,0 +1,12 @@
+You are the WealthWise AI Orchestrator. Your job is to analyze user requests and route them to the appropriate specialist agent.
+
+Classify the user's intent into one of these categories:
+- **financial-health**: General financial health assessment, savings analysis, debt review
+- **anomaly-detection**: Unusual spending patterns, suspicious transactions, spending spikes
+- **budget-optimization**: Budget adjustments, reallocation suggestions, spending targets
+- **forecasting**: Future projections, goal timelines, cash flow predictions
+
+Respond with ONLY a JSON object:
+{"agent": "financial-advisor" | "anomaly-detector" | "budget-optimizer" | "forecaster", "reason": "brief explanation"}
+
+If the intent is unclear or spans multiple areas, default to "financial-advisor".

--- a/agentic-ai/src/routes/agent.routes.ts
+++ b/agentic-ai/src/routes/agent.routes.ts
@@ -1,0 +1,195 @@
+import { Router, Response } from "express";
+import Anthropic from "@anthropic-ai/sdk";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { chatRateLimit, insightsRateLimit } from "../middleware/rate-limit";
+import { McpClientManager } from "../mcp/client";
+import { mcpToolsToClaudeTools } from "../mcp/tool-adapter";
+import { OrchestratorAgent } from "../agents/orchestrator";
+import { FinancialAdvisorAgent } from "../agents/financial-advisor";
+import { AnomalyDetectorAgent } from "../agents/anomaly-detector";
+import { BudgetOptimizerAgent } from "../agents/budget-optimizer";
+import { ForecasterAgent } from "../agents/forecaster";
+import { ConversationManager } from "../conversation/manager";
+import { costTracker } from "../utils/cost-tracker";
+import { logger } from "../utils/logger";
+
+const INSIGHT_AGENT_MAP: Record<string, string> = {
+  "financial-health": "financial-advisor",
+  anomalies: "anomaly-detector",
+  "budget-review": "budget-optimizer",
+  forecast: "forecaster",
+};
+
+const INSIGHT_PROMPTS: Record<string, string> = {
+  "financial-health": "Give me a comprehensive financial health assessment.",
+  anomalies: "Analyze my recent transactions for any unusual spending patterns or anomalies.",
+  "budget-review": "Review my budgets and suggest optimizations.",
+  forecast: "Project my financial outlook for the next 3, 6, and 12 months.",
+};
+
+export function createAgentRoutes(
+  anthropic: Anthropic,
+  mcpManager: McpClientManager,
+  conversationManager: ConversationManager
+): Router {
+  const router = Router();
+  const orchestrator = new OrchestratorAgent(anthropic);
+
+  const agents: Record<string, InstanceType<typeof FinancialAdvisorAgent>> = {
+    "financial-advisor": new FinancialAdvisorAgent(anthropic),
+    "anomaly-detector": new AnomalyDetectorAgent(anthropic),
+    "budget-optimizer": new BudgetOptimizerAgent(anthropic),
+    forecaster: new ForecasterAgent(anthropic),
+  };
+
+  router.post("/chat", chatRateLimit, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const { message } = req.body;
+      if (!message || typeof message !== "string") {
+        res.status(400).json({
+          success: false,
+          error: { code: "BAD_REQUEST", message: "message is required and must be a string" },
+        });
+        return;
+      }
+
+      const userId = req.userId!;
+      const userToken = req.userToken!;
+
+      const mcpClient = await mcpManager.createClient(userToken);
+      const mcpTools = await mcpManager.listTools(mcpClient);
+      const claudeTools = mcpToolsToClaudeTools(mcpTools);
+      const history = conversationManager.getHistory(userId);
+      const conversation = conversationManager.getOrCreate(userId);
+
+      const result = await orchestrator.run(message, claudeTools, mcpClient, history);
+
+      conversationManager.addMessage(userId, "user", message);
+      conversationManager.addMessage(userId, "assistant", result.response);
+
+      costTracker.trackUsage(
+        userId,
+        result.usage.inputTokens,
+        result.usage.outputTokens,
+        "claude-sonnet-4-20250514"
+      );
+
+      res.json({
+        success: true,
+        data: {
+          response: result.response,
+          agent: result.agent,
+          conversationId: conversation.id,
+          usage: result.usage,
+        },
+      });
+    } catch (error) {
+      logger.error({ error }, "Chat endpoint error");
+      res.status(500).json({
+        success: false,
+        error: { code: "INTERNAL_ERROR", message: "Failed to process chat request" },
+      });
+    }
+  });
+
+  router.post("/insights", insightsRateLimit, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const { type } = req.body;
+      const validTypes = Object.keys(INSIGHT_AGENT_MAP);
+      if (!type || !validTypes.includes(type)) {
+        res.status(400).json({
+          success: false,
+          error: {
+            code: "BAD_REQUEST",
+            message: `type must be one of: ${validTypes.join(", ")}`,
+          },
+        });
+        return;
+      }
+
+      const userId = req.userId!;
+      const userToken = req.userToken!;
+      const agentName = INSIGHT_AGENT_MAP[type];
+      const prompt = INSIGHT_PROMPTS[type];
+
+      const mcpClient = await mcpManager.createClient(userToken);
+      const mcpTools = await mcpManager.listTools(mcpClient);
+      const claudeTools = mcpToolsToClaudeTools(mcpTools);
+
+      const agent = agents[agentName];
+      const result = await agent.run(prompt, claudeTools, mcpClient, []);
+
+      costTracker.trackUsage(
+        userId,
+        result.usage.inputTokens,
+        result.usage.outputTokens,
+        "claude-sonnet-4-20250514"
+      );
+
+      res.json({
+        success: true,
+        data: {
+          response: result.response,
+          agent: result.agent,
+          conversationId: null,
+          usage: result.usage,
+        },
+      });
+    } catch (error) {
+      logger.error({ error }, "Insights endpoint error");
+      res.status(500).json({
+        success: false,
+        error: { code: "INTERNAL_ERROR", message: "Failed to generate insights" },
+      });
+    }
+  });
+
+  router.get("/insights/summary", insightsRateLimit, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = req.userId!;
+      const userToken = req.userToken!;
+
+      const mcpClient = await mcpManager.createClient(userToken);
+      const mcpTools = await mcpManager.listTools(mcpClient);
+      const claudeTools = mcpToolsToClaudeTools(mcpTools);
+
+      const agent = agents["financial-advisor"];
+      const result = await agent.run(
+        "Give me a brief financial summary: health score, top concern, and one actionable recommendation. Keep it under 200 words.",
+        claudeTools,
+        mcpClient,
+        []
+      );
+
+      costTracker.trackUsage(
+        userId,
+        result.usage.inputTokens,
+        result.usage.outputTokens,
+        "claude-sonnet-4-20250514"
+      );
+
+      res.json({
+        success: true,
+        data: {
+          response: result.response,
+          agent: "financial-advisor",
+          usage: result.usage,
+        },
+      });
+    } catch (error) {
+      logger.error({ error }, "Summary endpoint error");
+      res.status(500).json({
+        success: false,
+        error: { code: "INTERNAL_ERROR", message: "Failed to generate summary" },
+      });
+    }
+  });
+
+  router.delete("/conversations/:id", (req: AuthenticatedRequest, res: Response) => {
+    const userId = req.userId!;
+    conversationManager.clear(userId);
+    res.json({ success: true, data: { message: "Conversation cleared" } });
+  });
+
+  return router;
+}

--- a/agentic-ai/src/routes/health.routes.ts
+++ b/agentic-ai/src/routes/health.routes.ts
@@ -1,0 +1,16 @@
+import { Router, Request, Response } from "express";
+
+export function createHealthRoutes(): Router {
+  const router = Router();
+
+  router.get("/health", (_req: Request, res: Response) => {
+    res.json({
+      status: "healthy",
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+      mcpConnected: true,
+    });
+  });
+
+  return router;
+}

--- a/agentic-ai/src/server.ts
+++ b/agentic-ai/src/server.ts
@@ -1,0 +1,42 @@
+import express from "express";
+import cors from "cors";
+import Anthropic from "@anthropic-ai/sdk";
+import { Env } from "./config/env";
+import { authMiddleware } from "./middleware/auth";
+import { createAgentRoutes } from "./routes/agent.routes";
+import { createHealthRoutes } from "./routes/health.routes";
+import { McpClientManager } from "./mcp/client";
+import { ConversationManager } from "./conversation/manager";
+import { logger } from "./utils/logger";
+
+export function createServer(env: Env) {
+  const app = express();
+
+  app.use(cors());
+  app.use(express.json());
+
+  app.use((req, _res, next) => {
+    logger.info({ method: req.method, url: req.url }, "incoming request");
+    next();
+  });
+
+  const anthropic = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
+  const mcpManager = new McpClientManager(env.MCP_SERVER_URL);
+  const conversationManager = new ConversationManager();
+
+  conversationManager.startCleanup();
+
+  app.use(createHealthRoutes());
+
+  app.use("/api/v1/agent", authMiddleware(env.JWT_SECRET), createAgentRoutes(anthropic, mcpManager, conversationManager));
+
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    logger.error({ error: err.message }, "Unhandled error");
+    res.status(500).json({
+      success: false,
+      error: { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+    });
+  });
+
+  return { app, conversationManager };
+}

--- a/agentic-ai/src/utils/cost-tracker.ts
+++ b/agentic-ai/src/utils/cost-tracker.ts
@@ -1,0 +1,47 @@
+interface UsageRecord {
+  inputTokens: number;
+  outputTokens: number;
+  requests: number;
+  lastModel: string;
+  lastUpdated: Date;
+}
+
+class CostTracker {
+  private usage: Map<string, UsageRecord> = new Map();
+
+  trackUsage(
+    userId: string,
+    inputTokens: number,
+    outputTokens: number,
+    model: string
+  ): void {
+    const existing = this.usage.get(userId);
+
+    if (existing) {
+      existing.inputTokens += inputTokens;
+      existing.outputTokens += outputTokens;
+      existing.requests += 1;
+      existing.lastModel = model;
+      existing.lastUpdated = new Date();
+    } else {
+      this.usage.set(userId, {
+        inputTokens,
+        outputTokens,
+        requests: 1,
+        lastModel: model,
+        lastUpdated: new Date(),
+      });
+    }
+  }
+
+  getUsage(userId: string): UsageRecord | null {
+    return this.usage.get(userId) ?? null;
+  }
+
+  resetUsage(userId: string): void {
+    this.usage.delete(userId);
+  }
+}
+
+export const costTracker = new CostTracker();
+export type { UsageRecord };

--- a/agentic-ai/src/utils/logger.ts
+++ b/agentic-ai/src/utils/logger.ts
@@ -1,0 +1,11 @@
+import pino from "pino";
+
+const logger = pino({
+  level: process.env.NODE_ENV === "test" ? "silent" : "info",
+  transport:
+    process.env.NODE_ENV === "development"
+      ? { target: "pino/file", options: { destination: 1 } }
+      : undefined,
+});
+
+export { logger };

--- a/agentic-ai/tsconfig.json
+++ b/agentic-ai/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/agentic-ai/vitest.config.ts
+++ b/agentic-ai/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    setupFiles: ["./src/__tests__/setup.ts"],
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,6 +53,46 @@ services:
       - wealthwise-network
     restart: always
 
+  mcp:
+    build:
+      context: .
+      dockerfile: mcp/Dockerfile
+      target: production
+    container_name: wealthwise-mcp-prod
+    expose:
+      - "5100"
+    environment:
+      - NODE_ENV=production
+      - MONGODB_URI=mongodb://mongodb:27017/wealthwise
+      - JWT_SECRET=${JWT_SECRET}
+      - MCP_TRANSPORT=sse
+      - MCP_PORT=5100
+    depends_on:
+      - mongodb
+    networks:
+      - wealthwise-network
+    restart: always
+
+  agentic-ai:
+    build:
+      context: .
+      dockerfile: agentic-ai/Dockerfile
+      target: production
+    container_name: wealthwise-agentic-ai-prod
+    expose:
+      - "5200"
+    environment:
+      - NODE_ENV=production
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - MCP_SERVER_URL=http://mcp:5100
+      - JWT_SECRET=${JWT_SECRET}
+      - AGENT_PORT=5200
+    depends_on:
+      - mcp
+    networks:
+      - wealthwise-network
+    restart: always
+
   nginx:
     image: nginx:alpine
     container_name: wealthwise-nginx
@@ -65,6 +105,8 @@ services:
     depends_on:
       - web
       - api
+      - mcp
+      - agentic-ai
     networks:
       - wealthwise-network
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,42 @@ services:
       - wealthwise-network
     restart: unless-stopped
 
+  mcp:
+    build:
+      context: .
+      dockerfile: mcp/Dockerfile
+    container_name: wealthwise-mcp
+    ports:
+      - "5100:5100"
+    environment:
+      - MONGODB_URI=mongodb://mongodb:27017/wealthwise
+      - JWT_SECRET=${JWT_SECRET:-wealthwise-dev-jwt-secret-change-in-prod-32chars}
+      - MCP_TRANSPORT=sse
+      - MCP_PORT=5100
+    depends_on:
+      - mongodb
+    networks:
+      - wealthwise-network
+    restart: unless-stopped
+
+  agentic-ai:
+    build:
+      context: .
+      dockerfile: agentic-ai/Dockerfile
+    container_name: wealthwise-agentic-ai
+    ports:
+      - "5200:5200"
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - MCP_SERVER_URL=http://mcp:5100
+      - JWT_SECRET=${JWT_SECRET:-wealthwise-dev-jwt-secret-change-in-prod-32chars}
+      - AGENT_PORT=5200
+    depends_on:
+      - mcp
+    networks:
+      - wealthwise-network
+    restart: unless-stopped
+
 volumes:
   mongodb_data:
 

--- a/gcp/terraform/main.tf
+++ b/gcp/terraform/main.tf
@@ -65,6 +65,40 @@ resource "google_artifact_registry_repository" "web" {
   depends_on = [google_project_service.apis["artifactregistry.googleapis.com"]]
 }
 
+resource "google_artifact_registry_repository" "mcp" {
+  location      = var.region
+  repository_id = "wealthwise-mcp"
+  format        = "DOCKER"
+  description   = "WealthWise MCP server container images"
+
+  cleanup_policies {
+    id     = "keep-recent"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 10
+    }
+  }
+
+  depends_on = [google_project_service.apis["artifactregistry.googleapis.com"]]
+}
+
+resource "google_artifact_registry_repository" "agentic_ai" {
+  location      = var.region
+  repository_id = "wealthwise-agentic-ai"
+  format        = "DOCKER"
+  description   = "WealthWise Agentic AI container images"
+
+  cleanup_policies {
+    id     = "keep-recent"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 10
+    }
+  }
+
+  depends_on = [google_project_service.apis["artifactregistry.googleapis.com"]]
+}
+
 # VPC Connector for Cloud Run → MongoDB Atlas
 resource "google_vpc_access_connector" "connector" {
   name          = "wealthwise-connector"
@@ -86,6 +120,16 @@ resource "google_service_account" "web" {
   display_name = "WealthWise Web Service Account"
 }
 
+resource "google_service_account" "mcp" {
+  account_id   = "wealthwise-mcp"
+  display_name = "WealthWise MCP Service Account"
+}
+
+resource "google_service_account" "agentic_ai" {
+  account_id   = "wealthwise-agentic-ai"
+  display_name = "WealthWise Agentic AI Service Account"
+}
+
 # Secret Manager access for API
 resource "google_secret_manager_secret_iam_member" "api_secrets" {
   for_each  = toset(["jwt-secret", "jwt-refresh-secret", "mongodb-uri"])
@@ -100,6 +144,22 @@ resource "google_secret_manager_secret_iam_member" "web_secrets" {
   secret_id = each.key
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.web.email}"
+}
+
+# Secret Manager access for MCP
+resource "google_secret_manager_secret_iam_member" "mcp_secrets" {
+  for_each  = toset(["jwt-secret", "mongodb-uri"])
+  secret_id = each.key
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.mcp.email}"
+}
+
+# Secret Manager access for Agentic AI
+resource "google_secret_manager_secret_iam_member" "agentic_ai_secrets" {
+  for_each  = toset(["jwt-secret", "anthropic-api-key"])
+  secret_id = each.key
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.agentic_ai.email}"
 }
 
 # Cloud Run - API
@@ -289,6 +349,193 @@ resource "google_cloud_run_v2_service" "web" {
   ]
 }
 
+# Cloud Run - MCP
+resource "google_cloud_run_v2_service" "mcp" {
+  name     = "wealthwise-mcp"
+  location = var.region
+
+  template {
+    service_account = google_service_account.mcp.email
+
+    scaling {
+      min_instance_count = var.mcp_min_instances
+      max_instance_count = var.mcp_max_instances
+    }
+
+    vpc_access {
+      connector = google_vpc_access_connector.connector.id
+      egress    = "PRIVATE_RANGES_ONLY"
+    }
+
+    containers {
+      image = var.mcp_image
+
+      ports {
+        container_port = 5100
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      env {
+        name  = "NODE_ENV"
+        value = "production"
+      }
+
+      env {
+        name  = "MCP_PORT"
+        value = "5100"
+      }
+
+      env {
+        name  = "MCP_TRANSPORT"
+        value = "sse"
+      }
+
+      env {
+        name = "JWT_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = "jwt-secret"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "MONGODB_URI"
+        value_source {
+          secret_key_ref {
+            secret  = "mongodb-uri"
+            version = "latest"
+          }
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/health"
+          port = 5100
+        }
+        initial_delay_seconds = 5
+        period_seconds        = 5
+        failure_threshold     = 12
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/health"
+          port = 5100
+        }
+        period_seconds    = 10
+        failure_threshold = 3
+      }
+    }
+  }
+
+  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+
+  depends_on = [
+    google_project_service.apis["run.googleapis.com"],
+    google_secret_manager_secret_iam_member.mcp_secrets,
+  ]
+}
+
+# Cloud Run - Agentic AI
+resource "google_cloud_run_v2_service" "agentic_ai" {
+  name     = "wealthwise-agentic-ai"
+  location = var.region
+
+  template {
+    service_account = google_service_account.agentic_ai.email
+
+    scaling {
+      min_instance_count = var.agentic_ai_min_instances
+      max_instance_count = var.agentic_ai_max_instances
+    }
+
+    containers {
+      image = var.agentic_ai_image
+
+      ports {
+        container_port = 5200
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      env {
+        name  = "NODE_ENV"
+        value = "production"
+      }
+
+      env {
+        name  = "AGENT_PORT"
+        value = "5200"
+      }
+
+      env {
+        name  = "MCP_SERVER_URL"
+        value = "https://${var.domain}/mcp"
+      }
+
+      env {
+        name = "JWT_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = "jwt-secret"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "ANTHROPIC_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = "anthropic-api-key"
+            version = "latest"
+          }
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/health"
+          port = 5200
+        }
+        initial_delay_seconds = 5
+        period_seconds        = 5
+        failure_threshold     = 12
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/health"
+          port = 5200
+        }
+        period_seconds    = 10
+        failure_threshold = 3
+      }
+    }
+  }
+
+  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+
+  depends_on = [
+    google_project_service.apis["run.googleapis.com"],
+    google_secret_manager_secret_iam_member.agentic_ai_secrets,
+  ]
+}
+
 # Serverless NEGs for Load Balancer
 resource "google_compute_region_network_endpoint_group" "api_neg" {
   name                  = "wealthwise-api-neg"
@@ -310,6 +557,26 @@ resource "google_compute_region_network_endpoint_group" "web_neg" {
   }
 }
 
+resource "google_compute_region_network_endpoint_group" "mcp_neg" {
+  name                  = "wealthwise-mcp-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+
+  cloud_run {
+    service = google_cloud_run_v2_service.mcp.name
+  }
+}
+
+resource "google_compute_region_network_endpoint_group" "agentic_ai_neg" {
+  name                  = "wealthwise-agentic-ai-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+
+  cloud_run {
+    service = google_cloud_run_v2_service.agentic_ai.name
+  }
+}
+
 # Backend services
 resource "google_compute_backend_service" "api" {
   name                  = "wealthwise-api-backend"
@@ -328,6 +595,26 @@ resource "google_compute_backend_service" "web" {
 
   backend {
     group = google_compute_region_network_endpoint_group.web_neg.id
+  }
+}
+
+resource "google_compute_backend_service" "mcp" {
+  name                  = "wealthwise-mcp-backend"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+
+  backend {
+    group = google_compute_region_network_endpoint_group.mcp_neg.id
+  }
+}
+
+resource "google_compute_backend_service" "agentic_ai" {
+  name                  = "wealthwise-agentic-ai-backend"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+
+  backend {
+    group = google_compute_region_network_endpoint_group.agentic_ai_neg.id
   }
 }
 

--- a/helm/wealthwise/templates/_helpers.tpl
+++ b/helm/wealthwise/templates/_helpers.tpl
@@ -64,6 +64,30 @@ app.kubernetes.io/component: web
 {{ include "wealthwise.web.selectorLabels" . }}
 {{- end }}
 
+{{/* ---- MCP labels ---- */}}
+
+{{- define "wealthwise.mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wealthwise.fullname" . }}-mcp
+app.kubernetes.io/component: mcp
+{{- end }}
+
+{{- define "wealthwise.mcp.labels" -}}
+{{ include "wealthwise.commonLabels" . }}
+{{ include "wealthwise.mcp.selectorLabels" . }}
+{{- end }}
+
+{{/* ---- Agentic AI labels ---- */}}
+
+{{- define "wealthwise.agenticAi.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wealthwise.fullname" . }}-agentic-ai
+app.kubernetes.io/component: agentic-ai
+{{- end }}
+
+{{- define "wealthwise.agenticAi.labels" -}}
+{{ include "wealthwise.commonLabels" . }}
+{{ include "wealthwise.agenticAi.selectorLabels" . }}
+{{- end }}
+
 {{/* ---- Secret name (supports existingSecret) ---- */}}
 
 {{- define "wealthwise.secretName" -}}

--- a/helm/wealthwise/templates/agentic-ai-deployment.yaml
+++ b/helm/wealthwise/templates/agentic-ai-deployment.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.agenticAi.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-agentic-ai
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.agenticAi.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.agenticAi.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "wealthwise.agenticAi.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "wealthwise.agenticAi.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: agentic-ai
+          image: "{{ .Values.agenticAi.image.repository }}:{{ .Values.agenticAi.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.agenticAi.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.agenticAi.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "wealthwise.configMapName" . }}
+            - secretRef:
+                name: {{ include "wealthwise.secretName" . }}
+          env:
+            - name: AGENT_PORT
+              value: {{ .Values.agenticAi.port | quote }}
+            - name: MCP_SERVER_URL
+              value: "http://{{ include "wealthwise.fullname" . }}-mcp:{{ .Values.mcp.port }}"
+          {{- with .Values.agenticAi.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.agenticAi.port }}
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.agenticAi.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.agenticAi.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+      {{- if .Values.agenticAi.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.agenticAi.topologySpreadConstraints.maxSkew }}
+          topologyKey: {{ .Values.agenticAi.topologySpreadConstraints.topologyKey }}
+          whenUnsatisfied: {{ .Values.agenticAi.topologySpreadConstraints.whenUnsatisfied }}
+          labelSelector:
+            matchLabels:
+              {{- include "wealthwise.agenticAi.selectorLabels" . | nindent 14 }}
+      {{- end }}
+{{- end }}

--- a/helm/wealthwise/templates/agentic-ai-hpa.yaml
+++ b/helm/wealthwise/templates/agentic-ai-hpa.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.agenticAi.enabled .Values.agenticAi.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-agentic-ai-hpa
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.agenticAi.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "wealthwise.fullname" . }}-agentic-ai
+  minReplicas: {{ .Values.agenticAi.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.agenticAi.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.agenticAi.autoscaling.targetCPUUtilization }}
+{{- end }}

--- a/helm/wealthwise/templates/agentic-ai-pdb.yaml
+++ b/helm/wealthwise/templates/agentic-ai-pdb.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.agenticAi.enabled .Values.agenticAi.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-agentic-ai-pdb
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.agenticAi.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.agenticAi.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "wealthwise.agenticAi.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/wealthwise/templates/agentic-ai-service.yaml
+++ b/helm/wealthwise/templates/agentic-ai-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.agenticAi.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-agentic-ai
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.agenticAi.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.agenticAi.service.type }}
+  ports:
+    - port: {{ .Values.agenticAi.port }}
+      targetPort: {{ .Values.agenticAi.port }}
+      protocol: TCP
+  selector:
+    {{- include "wealthwise.agenticAi.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/wealthwise/templates/configmap.yaml
+++ b/helm/wealthwise/templates/configmap.yaml
@@ -10,4 +10,7 @@ data:
   API_PORT: {{ .Values.api.port | quote }}
   NODE_ENV: {{ .Values.config.nodeEnv | quote }}
   NEXT_TELEMETRY_DISABLED: "1"
+  MCP_PORT: {{ .Values.mcp.port | quote }}
+  MCP_TRANSPORT: "sse"
+  AGENT_PORT: {{ .Values.agenticAi.port | quote }}
 {{- end }}

--- a/helm/wealthwise/templates/ingress.yaml
+++ b/helm/wealthwise/templates/ingress.yaml
@@ -31,6 +31,20 @@ spec:
                 name: {{ include "wealthwise.fullname" . }}-api
                 port:
                   number: {{ .Values.api.port }}
+          - path: /mcp
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "wealthwise.fullname" . }}-mcp
+                port:
+                  number: {{ .Values.mcp.port }}
+          - path: /agent
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "wealthwise.fullname" . }}-agentic-ai
+                port:
+                  number: {{ .Values.agenticAi.port }}
           - path: /
             pathType: Prefix
             backend:

--- a/helm/wealthwise/templates/mcp-deployment.yaml
+++ b/helm/wealthwise/templates/mcp-deployment.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-mcp
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.mcp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.mcp.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "wealthwise.mcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "wealthwise.mcp.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mcp
+          image: "{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.mcp.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.mcp.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "wealthwise.configMapName" . }}
+            - secretRef:
+                name: {{ include "wealthwise.secretName" . }}
+          env:
+            - name: MCP_PORT
+              value: {{ .Values.mcp.port | quote }}
+            - name: MCP_TRANSPORT
+              value: "sse"
+          {{- with .Values.mcp.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.mcp.port }}
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.mcp.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.mcp.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+      {{- if .Values.mcp.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.mcp.topologySpreadConstraints.maxSkew }}
+          topologyKey: {{ .Values.mcp.topologySpreadConstraints.topologyKey }}
+          whenUnsatisfied: {{ .Values.mcp.topologySpreadConstraints.whenUnsatisfied }}
+          labelSelector:
+            matchLabels:
+              {{- include "wealthwise.mcp.selectorLabels" . | nindent 14 }}
+      {{- end }}
+{{- end }}

--- a/helm/wealthwise/templates/mcp-hpa.yaml
+++ b/helm/wealthwise/templates/mcp-hpa.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.mcp.enabled .Values.mcp.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-mcp-hpa
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.mcp.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "wealthwise.fullname" . }}-mcp
+  minReplicas: {{ .Values.mcp.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.mcp.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.mcp.autoscaling.targetCPUUtilization }}
+{{- end }}

--- a/helm/wealthwise/templates/mcp-pdb.yaml
+++ b/helm/wealthwise/templates/mcp-pdb.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.mcp.enabled .Values.mcp.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-mcp-pdb
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.mcp.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.mcp.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "wealthwise.mcp.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/wealthwise/templates/mcp-service.yaml
+++ b/helm/wealthwise/templates/mcp-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-mcp
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.mcp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.mcp.service.type }}
+  ports:
+    - port: {{ .Values.mcp.port }}
+      targetPort: {{ .Values.mcp.port }}
+      protocol: TCP
+  selector:
+    {{- include "wealthwise.mcp.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/wealthwise/templates/networkpolicy-agentic-ai-egress.yaml
+++ b/helm/wealthwise/templates/networkpolicy-agentic-ai-egress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-allow-agentic-ai-egress
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.commonLabels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wealthwise.agenticAi.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "wealthwise.mcp.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.mcp.port }}
+    - ports:
+        - protocol: TCP
+          port: 443
+    - ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+{{- end }}

--- a/helm/wealthwise/templates/networkpolicy-agentic-ai-ingress.yaml
+++ b/helm/wealthwise/templates/networkpolicy-agentic-ai-ingress.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-allow-agentic-ai-ingress
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.commonLabels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wealthwise.agenticAi.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: {{ .Values.agenticAi.port }}
+{{- end }}

--- a/helm/wealthwise/templates/networkpolicy-mcp-egress.yaml
+++ b/helm/wealthwise/templates/networkpolicy-mcp-egress.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-allow-mcp-egress
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.commonLabels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wealthwise.mcp.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicies.mongodbPort }}
+    - ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+{{- end }}

--- a/helm/wealthwise/templates/networkpolicy-mcp-ingress.yaml
+++ b/helm/wealthwise/templates/networkpolicy-mcp-ingress.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-allow-mcp-ingress
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.commonLabels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wealthwise.mcp.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "wealthwise.agenticAi.selectorLabels" . | nindent 14 }}
+        - namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: {{ .Values.mcp.port }}
+{{- end }}

--- a/helm/wealthwise/templates/secret.yaml
+++ b/helm/wealthwise/templates/secret.yaml
@@ -12,4 +12,5 @@ stringData:
   JWT_REFRESH_SECRET: {{ required "secrets.jwtRefreshSecret is required" .Values.secrets.jwtRefreshSecret | quote }}
   NEXTAUTH_SECRET: {{ required "secrets.nextauthSecret is required" .Values.secrets.nextauthSecret | quote }}
   MONGODB_URI: {{ required "secrets.mongodbUri is required" .Values.secrets.mongodbUri | quote }}
+  ANTHROPIC_API_KEY: {{ required "secrets.anthropicApiKey is required" .Values.secrets.anthropicApiKey | quote }}
 {{- end }}

--- a/helm/wealthwise/values.yaml
+++ b/helm/wealthwise/values.yaml
@@ -24,6 +24,7 @@ secrets:
   jwtRefreshSecret: ""
   nextauthSecret: ""
   mongodbUri: ""
+  anthropicApiKey: ""
 
 config:
   nodeEnv: "production"
@@ -99,6 +100,90 @@ web:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
+    targetCPUUtilization: 70
+
+  pdb:
+    enabled: true
+    minAvailable: 1
+
+  topologySpreadConstraints:
+    enabled: true
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfied: DoNotSchedule
+
+  extraEnv: []
+
+# ---- MCP Server ----
+
+mcp:
+  enabled: true
+  replicaCount: 2
+  port: 5100
+
+  image:
+    repository: wealthwise-mcp
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilization: 70
+
+  pdb:
+    enabled: true
+    minAvailable: 1
+
+  topologySpreadConstraints:
+    enabled: true
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfied: DoNotSchedule
+
+  extraEnv: []
+
+# ---- Agentic AI ----
+
+agenticAi:
+  enabled: true
+  replicaCount: 2
+  port: 5200
+
+  image:
+    repository: wealthwise-agentic-ai
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+
+  mcpServerUrl: ""
+
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 6
     targetCPUUtilization: 70
 
   pdb:

--- a/k8s/base/agentic-ai-deployment.yaml
+++ b/k8s/base/agentic-ai-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wealthwise-agentic-ai
+  namespace: wealthwise
+  labels:
+    app.kubernetes.io/name: wealthwise-agentic-ai
+    app.kubernetes.io/component: agentic-ai
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wealthwise-agentic-ai
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: wealthwise-agentic-ai
+        app.kubernetes.io/component: agentic-ai
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: agentic-ai
+          image: wealthwise-agentic-ai:latest
+          ports:
+            - containerPort: 5200
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: wealthwise-config
+            - secretRef:
+                name: wealthwise-secrets
+          env:
+            - name: AGENT_PORT
+              value: "5200"
+            - name: MCP_SERVER_URL
+              value: "http://wealthwise-mcp:5100"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5200
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 5200
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfied: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: wealthwise-agentic-ai

--- a/k8s/base/agentic-ai-hpa.yaml
+++ b/k8s/base/agentic-ai-hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: wealthwise-agentic-ai-hpa
+  namespace: wealthwise
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: wealthwise-agentic-ai
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/base/agentic-ai-pdb.yaml
+++ b/k8s/base/agentic-ai-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: wealthwise-agentic-ai-pdb
+  namespace: wealthwise
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wealthwise-agentic-ai

--- a/k8s/base/agentic-ai-service.yaml
+++ b/k8s/base/agentic-ai-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wealthwise-agentic-ai
+  namespace: wealthwise
+  labels:
+    app.kubernetes.io/name: wealthwise-agentic-ai
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5200
+      targetPort: 5200
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: wealthwise-agentic-ai

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -5,5 +5,8 @@ metadata:
   namespace: wealthwise
 data:
   API_PORT: "4000"
+  MCP_PORT: "5100"
+  MCP_TRANSPORT: "sse"
+  AGENT_PORT: "5200"
   NODE_ENV: "production"
   NEXT_TELEMETRY_DISABLED: "1"

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -27,6 +27,20 @@ spec:
                 name: wealthwise-api
                 port:
                   number: 4000
+          - path: /mcp
+            pathType: Prefix
+            backend:
+              service:
+                name: wealthwise-mcp
+                port:
+                  number: 5100
+          - path: /agent
+            pathType: Prefix
+            backend:
+              service:
+                name: wealthwise-agentic-ai
+                port:
+                  number: 5200
           - path: /
             pathType: Prefix
             backend:

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -14,6 +14,14 @@ resources:
   - web-service.yaml
   - web-hpa.yaml
   - web-pdb.yaml
+  - mcp-deployment.yaml
+  - mcp-service.yaml
+  - mcp-hpa.yaml
+  - mcp-pdb.yaml
+  - agentic-ai-deployment.yaml
+  - agentic-ai-service.yaml
+  - agentic-ai-hpa.yaml
+  - agentic-ai-pdb.yaml
   - ingress.yaml
   - network-policy.yaml
 

--- a/k8s/base/mcp-deployment.yaml
+++ b/k8s/base/mcp-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wealthwise-mcp
+  namespace: wealthwise
+  labels:
+    app.kubernetes.io/name: wealthwise-mcp
+    app.kubernetes.io/component: mcp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wealthwise-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: wealthwise-mcp
+        app.kubernetes.io/component: mcp
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mcp
+          image: wealthwise-mcp:latest
+          ports:
+            - containerPort: 5100
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: wealthwise-config
+            - secretRef:
+                name: wealthwise-secrets
+          env:
+            - name: MCP_PORT
+              value: "5100"
+            - name: MCP_TRANSPORT
+              value: "sse"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5100
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 5100
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfied: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: wealthwise-mcp

--- a/k8s/base/mcp-hpa.yaml
+++ b/k8s/base/mcp-hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: wealthwise-mcp-hpa
+  namespace: wealthwise
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: wealthwise-mcp
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/base/mcp-pdb.yaml
+++ b/k8s/base/mcp-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: wealthwise-mcp-pdb
+  namespace: wealthwise
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wealthwise-mcp

--- a/k8s/base/mcp-service.yaml
+++ b/k8s/base/mcp-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wealthwise-mcp
+  namespace: wealthwise
+  labels:
+    app.kubernetes.io/name: wealthwise-mcp
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5100
+      targetPort: 5100
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: wealthwise-mcp

--- a/k8s/base/network-policy.yaml
+++ b/k8s/base/network-policy.yaml
@@ -53,6 +53,102 @@ spec:
         - protocol: UDP
           port: 53
 ---
+# MCP: accept traffic from agentic-ai and ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-mcp-ingress
+  namespace: wealthwise
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: wealthwise-mcp
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: wealthwise-agentic-ai
+        - namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 5100
+---
+# MCP: egress to MongoDB + DNS
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-mcp-egress-mongodb
+  namespace: wealthwise
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: wealthwise-mcp
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 27017
+    - ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+---
+# Agentic AI: accept traffic from ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-agentic-ai-ingress
+  namespace: wealthwise
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: wealthwise-agentic-ai
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 5200
+---
+# Agentic AI: egress to MCP, Anthropic API (HTTPS), DNS
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-agentic-ai-egress
+  namespace: wealthwise
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: wealthwise-agentic-ai
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: wealthwise-mcp
+      ports:
+        - protocol: TCP
+          port: 5100
+    - ports:
+        - protocol: TCP
+          port: 443
+    - ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/k8s/base/secrets.template.yaml
+++ b/k8s/base/secrets.template.yaml
@@ -7,6 +7,7 @@
 #     --from-literal=JWT_REFRESH_SECRET=<value> \
 #     --from-literal=NEXTAUTH_SECRET=<value> \
 #     --from-literal=MONGODB_URI=<value> \
+#     --from-literal=ANTHROPIC_API_KEY=<value> \
 #     --dry-run=client -o yaml | kubeseal --format=yaml > sealed-secret.yaml
 apiVersion: v1
 kind: Secret
@@ -19,3 +20,4 @@ stringData:
   JWT_REFRESH_SECRET: "<REPLACE>"
   NEXTAUTH_SECRET: "<REPLACE>"
   MONGODB_URI: "<REPLACE>"
+  ANTHROPIC_API_KEY: "<REPLACE>"

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -44,8 +44,54 @@ patches:
         path: /spec/maxReplicas
         value: 3
   - target:
+      kind: Deployment
+      name: wealthwise-mcp
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: "256Mi"
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: "250m"
+  - target:
+      kind: Deployment
+      name: wealthwise-agentic-ai
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: "256Mi"
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: "250m"
+  - target:
       kind: HorizontalPodAutoscaler
       name: wealthwise-web-hpa
+    patch: |-
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+      - op: replace
+        path: /spec/maxReplicas
+        value: 3
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: wealthwise-mcp-hpa
+    patch: |-
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+      - op: replace
+        path: /spec/maxReplicas
+        value: 3
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: wealthwise-agentic-ai-hpa
     patch: |-
       - op: replace
         path: /spec/minReplicas

--- a/k8s/overlays/production/agentic-ai-deployment-patch.yaml
+++ b/k8s/overlays/production/agentic-ai-deployment-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wealthwise-agentic-ai
+  namespace: wealthwise
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: agentic-ai
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 patches:
   - path: api-deployment-patch.yaml
   - path: web-deployment-patch.yaml
+  - path: mcp-deployment-patch.yaml
+  - path: agentic-ai-deployment-patch.yaml
   - target:
       kind: Ingress
       name: wealthwise-ingress

--- a/k8s/overlays/production/mcp-deployment-patch.yaml
+++ b/k8s/overlays/production/mcp-deployment-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wealthwise-mcp
+  namespace: wealthwise
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: mcp
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,25 @@
+# Build stage
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json tsconfig.json ./
+RUN npm install
+
+COPY src/ ./src/
+RUN npx tsc
+
+# Production stage
+FROM node:20-alpine AS production
+
+WORKDIR /app
+
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/dist/ ./dist/
+COPY --from=builder /app/node_modules/ ./node_modules/
+
+ENV NODE_ENV=production
+
+EXPOSE 5100
+
+CMD ["node", "dist/index.js"]

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@wealthwise/mcp",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "node --max-old-space-size=4096 ./node_modules/.bin/tsc",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "node --max-old-space-size=4096 ./node_modules/.bin/tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "express": "^4.19.0",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.5.0",
+    "pino": "^9.6.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.6",
+    "mongodb-memory-server": "^10.0.0",
+    "tsx": "^4.16.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/mcp/src/__tests__/auth/token-resolver.test.ts
+++ b/mcp/src/__tests__/auth/token-resolver.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import jwt from "jsonwebtoken";
+import { resolveUserId } from "../../auth/token-resolver";
+
+const JWT_SECRET = process.env.JWT_SECRET!;
+
+describe("token-resolver", () => {
+  describe("stdio transport", () => {
+    it("should return MCP_USER_ID when transport is stdio", () => {
+      const userId = resolveUserId("stdio");
+      expect(userId).toBe("000000000000000000000000");
+    });
+
+    it("should throw when MCP_USER_ID is not set for stdio", () => {
+      const original = process.env.MCP_USER_ID;
+      delete process.env.MCP_USER_ID;
+      try {
+        expect(() => resolveUserId("stdio")).toThrow(
+          "MCP_USER_ID must be set when using stdio transport",
+        );
+      } finally {
+        process.env.MCP_USER_ID = original;
+      }
+    });
+  });
+
+  describe("SSE transport", () => {
+    it("should extract userId from a valid JWT token", () => {
+      const token = jwt.sign({ userId: "user123" }, JWT_SECRET, {
+        expiresIn: "1h",
+      });
+      const userId = resolveUserId("sse", token);
+      expect(userId).toBe("user123");
+    });
+
+    it("should throw when no token is provided", () => {
+      expect(() => resolveUserId("sse")).toThrow(
+        "Authorization token is required",
+      );
+    });
+
+    it("should throw for an invalid token", () => {
+      expect(() => resolveUserId("sse", "invalid-token")).toThrow(
+        "Invalid or expired token",
+      );
+    });
+
+    it("should throw for an expired token", () => {
+      const token = jwt.sign({ userId: "user123" }, JWT_SECRET, {
+        expiresIn: "-1h",
+      });
+      expect(() => resolveUserId("sse", token)).toThrow(
+        "Invalid or expired token",
+      );
+    });
+
+    it("should throw when token has no userId", () => {
+      const token = jwt.sign({ sub: "user123" }, JWT_SECRET, {
+        expiresIn: "1h",
+      });
+      expect(() => resolveUserId("sse", token)).toThrow(
+        "Invalid token: missing userId",
+      );
+    });
+  });
+});

--- a/mcp/src/__tests__/setup.ts
+++ b/mcp/src/__tests__/setup.ts
@@ -1,0 +1,29 @@
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { beforeAll, afterAll, afterEach } from "vitest";
+
+let mongoServer: MongoMemoryServer;
+
+process.env.JWT_SECRET = "test-jwt-secret-that-is-at-least-32-chars-long";
+process.env.MONGODB_URI = "mongodb://127.0.0.1:27017/test";
+process.env.NODE_ENV = "test";
+process.env.MCP_TRANSPORT = "stdio";
+process.env.MCP_USER_ID = "000000000000000000000000";
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri();
+  await mongoose.connect(uri);
+});
+
+afterEach(async () => {
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    await collections[key].deleteMany({});
+  }
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});

--- a/mcp/src/__tests__/tools/accounts.tool.test.ts
+++ b/mcp/src/__tests__/tools/accounts.tool.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { Account } from "../../models/account.model";
+import { Transaction } from "../../models/transaction.model";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAccountTools } from "../../tools/accounts.tool";
+
+const userId = new mongoose.Types.ObjectId().toString();
+const getUserId = () => userId;
+
+function createTestServer() {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  registerAccountTools(server, getUserId);
+  return server;
+}
+
+async function createAccount(overrides: Record<string, unknown> = {}) {
+  return Account.create({
+    userId,
+    name: "Test Checking",
+    type: "checking",
+    balance: 1000,
+    ...overrides,
+  });
+}
+
+describe("accounts tools", () => {
+  describe("list_accounts", () => {
+    it("should list non-archived accounts", async () => {
+      await createAccount({ name: "Active" });
+      await createAccount({ name: "Archived", isArchived: true });
+
+      const accounts = await Account.find({ userId, isArchived: false });
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0].name).toBe("Active");
+    });
+
+    it("should return empty array when no accounts", async () => {
+      const accounts = await Account.find({ userId, isArchived: false });
+      expect(accounts).toHaveLength(0);
+    });
+  });
+
+  describe("get_account", () => {
+    it("should get account by ID", async () => {
+      const account = await createAccount();
+      const found = await Account.findOne({ _id: account._id, userId });
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe("Test Checking");
+    });
+
+    it("should not find account belonging to another user", async () => {
+      const account = await createAccount({
+        userId: new mongoose.Types.ObjectId(),
+      });
+      const found = await Account.findOne({ _id: account._id, userId });
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("create_account", () => {
+    it("should create an account with defaults", async () => {
+      const account = await Account.create({
+        userId,
+        name: "Savings",
+        type: "savings",
+      });
+      expect(account.balance).toBe(0);
+      expect(account.currency).toBe("USD");
+      expect(account.color).toBe("#6366f1");
+      expect(account.isArchived).toBe(false);
+    });
+
+    it("should create an account with custom values", async () => {
+      const account = await Account.create({
+        userId,
+        name: "Euro",
+        type: "investment",
+        balance: 5000,
+        currency: "EUR",
+        color: "#ff0000",
+      });
+      expect(account.balance).toBe(5000);
+      expect(account.currency).toBe("EUR");
+      expect(account.color).toBe("#ff0000");
+    });
+  });
+
+  describe("update_account", () => {
+    it("should update account fields", async () => {
+      const account = await createAccount();
+      const updated = await Account.findOneAndUpdate(
+        { _id: account._id, userId },
+        { $set: { name: "Updated", balance: 2000 } },
+        { new: true },
+      );
+      expect(updated!.name).toBe("Updated");
+      expect(updated!.balance).toBe(2000);
+    });
+
+    it("should not update account of another user", async () => {
+      const account = await createAccount({
+        userId: new mongoose.Types.ObjectId(),
+      });
+      const updated = await Account.findOneAndUpdate(
+        { _id: account._id, userId },
+        { $set: { name: "Hacked" } },
+        { new: true },
+      );
+      expect(updated).toBeNull();
+    });
+  });
+
+  describe("archive_account", () => {
+    it("should soft-delete by setting isArchived to true", async () => {
+      const account = await createAccount();
+      const archived = await Account.findOneAndUpdate(
+        { _id: account._id, userId },
+        { $set: { isArchived: true } },
+        { new: true },
+      );
+      expect(archived!.isArchived).toBe(true);
+    });
+  });
+
+  describe("get_balance_history", () => {
+    it("should return monthly balance snapshots", async () => {
+      const account = await createAccount({ balance: 0 });
+      const categoryId = new mongoose.Types.ObjectId();
+
+      await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "income",
+        amount: 3000,
+        categoryId,
+        description: "Salary",
+        date: new Date(2024, 0, 15),
+      });
+      await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 1000,
+        categoryId,
+        description: "Rent",
+        date: new Date(2024, 0, 20),
+      });
+
+      const pipeline = [
+        {
+          $match: {
+            accountId: account._id,
+            userId: new mongoose.Types.ObjectId(userId),
+          },
+        },
+        {
+          $group: {
+            _id: { year: { $year: "$date" }, month: { $month: "$date" } },
+            income: {
+              $sum: { $cond: [{ $eq: ["$type", "income"] }, "$amount", 0] },
+            },
+            expense: {
+              $sum: { $cond: [{ $eq: ["$type", "expense"] }, "$amount", 0] },
+            },
+          },
+        },
+        { $sort: { "_id.year": 1 as const, "_id.month": 1 as const } },
+      ];
+
+      const history = await Transaction.aggregate(pipeline);
+      expect(history).toHaveLength(1);
+      expect(history[0].income).toBe(3000);
+      expect(history[0].expense).toBe(1000);
+    });
+  });
+});

--- a/mcp/src/__tests__/tools/analytics.tool.test.ts
+++ b/mcp/src/__tests__/tools/analytics.tool.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from "vitest";
+import mongoose from "mongoose";
+import { Transaction } from "../../models/transaction.model";
+import { Account } from "../../models/account.model";
+import { Category } from "../../models/category.model";
+
+const userId = new mongoose.Types.ObjectId().toString();
+
+async function seedTransactions() {
+  const account = await Account.create({
+    userId,
+    name: "Main",
+    type: "checking",
+    balance: 5000,
+  });
+  const foodCat = await Category.create({
+    name: "Food",
+    icon: "F",
+    color: "#ff0000",
+    type: "expense",
+    isDefault: true,
+  });
+  const salaryCat = await Category.create({
+    name: "Salary",
+    icon: "S",
+    color: "#00ff00",
+    type: "income",
+    isDefault: true,
+  });
+
+  // Create transactions across multiple months
+  const txData = [
+    { type: "income", amount: 5000, categoryId: salaryCat._id, date: new Date(2024, 0, 15), description: "Jan Salary" },
+    { type: "expense", amount: 200, categoryId: foodCat._id, date: new Date(2024, 0, 20), description: "Jan Food" },
+    { type: "income", amount: 5000, categoryId: salaryCat._id, date: new Date(2024, 1, 15), description: "Feb Salary" },
+    { type: "expense", amount: 300, categoryId: foodCat._id, date: new Date(2024, 1, 20), description: "Feb Food" },
+    { type: "expense", amount: 150, categoryId: foodCat._id, date: new Date(2024, 1, 25), description: "Feb Food 2" },
+  ];
+
+  for (const d of txData) {
+    await Transaction.create({
+      userId,
+      accountId: account._id,
+      ...d,
+    });
+  }
+
+  return { account, foodCat, salaryCat };
+}
+
+describe("analytics tools", () => {
+  describe("spending_by_category", () => {
+    it("should aggregate expense totals by category", async () => {
+      const { foodCat } = await seedTransactions();
+
+      const results = await Transaction.aggregate([
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: "expense",
+            date: { $gte: new Date(2024, 0, 1), $lte: new Date(2024, 1, 28) },
+          },
+        },
+        { $group: { _id: "$categoryId", total: { $sum: "$amount" }, count: { $sum: 1 } } },
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].total).toBe(650); // 200 + 300 + 150
+      expect(results[0].count).toBe(3);
+    });
+  });
+
+  describe("income_vs_expense", () => {
+    it("should return monthly income vs expense comparison", async () => {
+      await seedTransactions();
+
+      const results = await Transaction.aggregate([
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: { $in: ["income", "expense"] },
+            date: { $gte: new Date(2024, 0, 1) },
+          },
+        },
+        {
+          $group: {
+            _id: { year: { $year: "$date" }, month: { $month: "$date" }, type: "$type" },
+            total: { $sum: "$amount" },
+          },
+        },
+        { $sort: { "_id.year": 1, "_id.month": 1 } },
+      ]);
+
+      expect(results.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe("monthly_summary", () => {
+    it("should return income, expense, and savings for a month", async () => {
+      await seedTransactions();
+
+      const results = await Transaction.aggregate([
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: { $in: ["income", "expense"] },
+            date: { $gte: new Date(2024, 0, 1), $lte: new Date(2024, 0, 31, 23, 59, 59, 999) },
+          },
+        },
+        { $group: { _id: "$type", total: { $sum: "$amount" }, count: { $sum: 1 } } },
+      ]);
+
+      let income = 0;
+      let expense = 0;
+      for (const r of results) {
+        if (r._id === "income") income = r.total;
+        if (r._id === "expense") expense = r.total;
+      }
+
+      expect(income).toBe(5000);
+      expect(expense).toBe(200);
+      expect(income - expense).toBe(4800);
+    });
+  });
+
+  describe("get_trends", () => {
+    it("should return monthly trends with running net worth", async () => {
+      await seedTransactions();
+
+      const results = await Transaction.aggregate([
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: { $in: ["income", "expense"] },
+          },
+        },
+        {
+          $group: {
+            _id: { year: { $year: "$date" }, month: { $month: "$date" }, type: "$type" },
+            total: { $sum: "$amount" },
+          },
+        },
+      ]);
+
+      expect(results.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("spending_by_day_of_week", () => {
+    it("should aggregate expenses by day of week", async () => {
+      await seedTransactions();
+
+      const results = await Transaction.aggregate([
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: "expense",
+            date: { $gte: new Date(2024, 0, 1), $lte: new Date(2024, 1, 28) },
+          },
+        },
+        {
+          $group: {
+            _id: { $dayOfWeek: "$date" },
+            total: { $sum: "$amount" },
+            count: { $sum: 1 },
+          },
+        },
+      ]);
+
+      const totalSpent = results.reduce((sum: number, r: { total: number }) => sum + r.total, 0);
+      expect(totalSpent).toBe(650);
+    });
+  });
+
+  describe("category_monthly_breakdown", () => {
+    it("should break down expenses by category per month", async () => {
+      await seedTransactions();
+
+      const results = await Transaction.aggregate([
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: "expense",
+            date: { $gte: new Date(2024, 0, 1) },
+          },
+        },
+        {
+          $group: {
+            _id: {
+              year: { $year: "$date" },
+              month: { $month: "$date" },
+              categoryId: "$categoryId",
+            },
+            total: { $sum: "$amount" },
+          },
+        },
+      ]);
+
+      expect(results.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("get_net_worth", () => {
+    it("should return empty when no accounts exist", async () => {
+      const accounts = await Account.find({ userId });
+      expect(accounts).toHaveLength(0);
+    });
+
+    it("should return monthly net worth progression", async () => {
+      await seedTransactions();
+
+      const monthly = await Transaction.aggregate([
+        { $match: { userId: new mongoose.Types.ObjectId(userId) } },
+        {
+          $group: {
+            _id: { year: { $year: "$date" }, month: { $month: "$date" } },
+            income: { $sum: { $cond: [{ $eq: ["$type", "income"] }, "$amount", 0] } },
+            expense: { $sum: { $cond: [{ $eq: ["$type", "expense"] }, "$amount", 0] } },
+          },
+        },
+        { $sort: { "_id.year": 1, "_id.month": 1 } },
+        {
+          $project: {
+            _id: 0,
+            year: "$_id.year",
+            month: "$_id.month",
+            net: { $subtract: ["$income", "$expense"] },
+          },
+        },
+      ]);
+
+      expect(monthly).toHaveLength(2);
+
+      let running = 0;
+      const result = monthly.map((entry: { net: number }) => {
+        running += entry.net;
+        return running;
+      });
+
+      // Jan: 5000-200=4800, Feb: 5000-450=4550
+      expect(result[0]).toBe(4800);
+      expect(result[1]).toBe(4800 + 4550);
+    });
+  });
+});

--- a/mcp/src/__tests__/tools/budgets.tool.test.ts
+++ b/mcp/src/__tests__/tools/budgets.tool.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import mongoose from "mongoose";
+import { Budget } from "../../models/budget.model";
+import { Transaction } from "../../models/transaction.model";
+import { Category } from "../../models/category.model";
+import { Account } from "../../models/account.model";
+
+const userId = new mongoose.Types.ObjectId().toString();
+
+async function createTestCategory() {
+  return Category.create({
+    name: "Food",
+    icon: "F",
+    color: "#ff0000",
+    type: "expense",
+    isDefault: true,
+  });
+}
+
+describe("budgets tools", () => {
+  describe("list_budgets", () => {
+    it("should list all budgets for user", async () => {
+      const cat = await createTestCategory();
+      await Budget.create({
+        userId,
+        categoryId: cat._id,
+        amount: 500,
+        period: "monthly",
+      });
+      await Budget.create({
+        userId,
+        categoryId: cat._id,
+        amount: 100,
+        period: "weekly",
+      });
+
+      const budgets = await Budget.find({ userId });
+      expect(budgets).toHaveLength(2);
+    });
+
+    it("should not list budgets of other users", async () => {
+      const cat = await createTestCategory();
+      await Budget.create({
+        userId: new mongoose.Types.ObjectId(),
+        categoryId: cat._id,
+        amount: 500,
+        period: "monthly",
+      });
+
+      const budgets = await Budget.find({ userId });
+      expect(budgets).toHaveLength(0);
+    });
+  });
+
+  describe("create_budget", () => {
+    it("should create a budget with defaults", async () => {
+      const cat = await createTestCategory();
+      const budget = await Budget.create({
+        userId,
+        categoryId: cat._id,
+        amount: 500,
+        period: "monthly",
+      });
+
+      expect(budget.alertThreshold).toBe(0.8);
+      expect(budget.isActive).toBe(true);
+    });
+
+    it("should create a budget with custom alert threshold", async () => {
+      const cat = await createTestCategory();
+      const budget = await Budget.create({
+        userId,
+        categoryId: cat._id,
+        amount: 200,
+        period: "weekly",
+        alertThreshold: 0.9,
+      });
+
+      expect(budget.alertThreshold).toBe(0.9);
+    });
+  });
+
+  describe("update_budget", () => {
+    it("should update budget amount and period", async () => {
+      const cat = await createTestCategory();
+      const budget = await Budget.create({
+        userId,
+        categoryId: cat._id,
+        amount: 500,
+        period: "monthly",
+      });
+
+      const updated = await Budget.findOneAndUpdate(
+        { _id: budget._id, userId },
+        { $set: { amount: 600, period: "weekly" } },
+        { new: true },
+      );
+
+      expect(updated!.amount).toBe(600);
+      expect(updated!.period).toBe("weekly");
+    });
+
+    it("should not update budget of another user", async () => {
+      const cat = await createTestCategory();
+      const budget = await Budget.create({
+        userId: new mongoose.Types.ObjectId(),
+        categoryId: cat._id,
+        amount: 500,
+        period: "monthly",
+      });
+
+      const updated = await Budget.findOneAndUpdate(
+        { _id: budget._id, userId },
+        { $set: { amount: 9999 } },
+        { new: true },
+      );
+      expect(updated).toBeNull();
+    });
+  });
+
+  describe("get_budget_summary", () => {
+    it("should calculate spent amount and status", async () => {
+      const cat = await createTestCategory();
+      const account = await Account.create({
+        userId,
+        name: "Main",
+        type: "checking",
+      });
+
+      await Budget.create({
+        userId,
+        categoryId: cat._id,
+        amount: 500,
+        period: "monthly",
+      });
+
+      const now = new Date();
+      await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 200,
+        categoryId: cat._id,
+        description: "Groceries",
+        date: now,
+      });
+
+      const result = await Transaction.aggregate([
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            categoryId: cat._id,
+            type: "expense",
+            date: {
+              $gte: new Date(now.getFullYear(), now.getMonth(), 1),
+              $lte: now,
+            },
+          },
+        },
+        { $group: { _id: null, totalSpent: { $sum: "$amount" } } },
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].totalSpent).toBe(200);
+    });
+
+    it("should return over_budget status when spending exceeds budget", async () => {
+      const cat = await createTestCategory();
+      const account = await Account.create({
+        userId,
+        name: "Main",
+        type: "checking",
+      });
+
+      const budget = await Budget.create({
+        userId,
+        categoryId: cat._id,
+        amount: 100,
+        period: "monthly",
+      });
+
+      const now = new Date();
+      await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 150,
+        categoryId: cat._id,
+        description: "Big expense",
+        date: now,
+      });
+
+      const result = await Transaction.aggregate([
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            categoryId: cat._id,
+            type: "expense",
+            date: {
+              $gte: new Date(now.getFullYear(), now.getMonth(), 1),
+              $lte: now,
+            },
+          },
+        },
+        { $group: { _id: null, totalSpent: { $sum: "$amount" } } },
+      ]);
+
+      const spent = result[0].totalSpent;
+      const percentage = spent / budget.amount;
+      expect(percentage).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/mcp/src/__tests__/tools/categories.tool.test.ts
+++ b/mcp/src/__tests__/tools/categories.tool.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import mongoose from "mongoose";
+import { Category } from "../../models/category.model";
+
+const userId = new mongoose.Types.ObjectId().toString();
+
+describe("categories tools", () => {
+  describe("list_categories", () => {
+    it("should list user categories and system defaults", async () => {
+      await Category.create({
+        userId: null,
+        name: "Groceries",
+        icon: "G",
+        color: "#00ff00",
+        type: "expense",
+        isDefault: true,
+      });
+      await Category.create({
+        userId,
+        name: "Custom Cat",
+        icon: "C",
+        color: "#0000ff",
+        type: "expense",
+        isDefault: false,
+      });
+      await Category.create({
+        userId: new mongoose.Types.ObjectId(),
+        name: "Other User Cat",
+        icon: "O",
+        color: "#ff0000",
+        type: "expense",
+        isDefault: false,
+      });
+
+      const categories = await Category.find({
+        $or: [{ userId }, { userId: null }],
+      });
+      expect(categories).toHaveLength(2);
+    });
+
+    it("should return only defaults when user has no custom categories", async () => {
+      await Category.create({
+        userId: null,
+        name: "Default",
+        icon: "D",
+        color: "#000",
+        type: "income",
+        isDefault: true,
+      });
+
+      const categories = await Category.find({
+        $or: [{ userId }, { userId: null }],
+      });
+      expect(categories).toHaveLength(1);
+      expect(categories[0].isDefault).toBe(true);
+    });
+  });
+
+  describe("create_category", () => {
+    it("should create a custom category", async () => {
+      const cat = await Category.create({
+        userId,
+        name: "Hobbies",
+        icon: "H",
+        color: "#purple",
+        type: "expense",
+        isDefault: false,
+      });
+
+      expect(cat.userId!.toString()).toBe(userId);
+      expect(cat.name).toBe("Hobbies");
+      expect(cat.isDefault).toBe(false);
+    });
+  });
+});

--- a/mcp/src/__tests__/tools/goals.tool.test.ts
+++ b/mcp/src/__tests__/tools/goals.tool.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import mongoose from "mongoose";
+import { Goal } from "../../models/goal.model";
+
+const userId = new mongoose.Types.ObjectId().toString();
+
+describe("goals tools", () => {
+  describe("list_goals", () => {
+    it("should list all goals for user", async () => {
+      await Goal.create({
+        userId,
+        name: "Vacation",
+        targetAmount: 5000,
+      });
+      await Goal.create({
+        userId,
+        name: "Car",
+        targetAmount: 20000,
+      });
+
+      const goals = await Goal.find({ userId });
+      expect(goals).toHaveLength(2);
+    });
+  });
+
+  describe("create_goal", () => {
+    it("should create a goal with defaults", async () => {
+      const goal = await Goal.create({
+        userId,
+        name: "Emergency Fund",
+        targetAmount: 10000,
+      });
+
+      expect(goal.currentAmount).toBe(0);
+      expect(goal.isCompleted).toBe(false);
+      expect(goal.color).toBe("#10b981");
+    });
+
+    it("should create a goal with custom values", async () => {
+      const deadline = new Date(2025, 11, 31);
+      const goal = await Goal.create({
+        userId,
+        name: "House",
+        targetAmount: 50000,
+        currentAmount: 10000,
+        deadline,
+        color: "#ff0000",
+        icon: "H",
+      });
+
+      expect(goal.currentAmount).toBe(10000);
+      expect(goal.deadline!.getTime()).toBe(deadline.getTime());
+      expect(goal.color).toBe("#ff0000");
+    });
+  });
+
+  describe("update_goal", () => {
+    it("should update goal fields", async () => {
+      const goal = await Goal.create({
+        userId,
+        name: "Old Goal",
+        targetAmount: 1000,
+      });
+
+      const updated = await Goal.findOneAndUpdate(
+        { _id: goal._id, userId },
+        { $set: { name: "New Goal", targetAmount: 2000 } },
+        { new: true },
+      );
+
+      expect(updated!.name).toBe("New Goal");
+      expect(updated!.targetAmount).toBe(2000);
+    });
+
+    it("should not update goal of another user", async () => {
+      const goal = await Goal.create({
+        userId: new mongoose.Types.ObjectId(),
+        name: "Other",
+        targetAmount: 1000,
+      });
+
+      const updated = await Goal.findOneAndUpdate(
+        { _id: goal._id, userId },
+        { $set: { name: "Hacked" } },
+        { new: true },
+      );
+      expect(updated).toBeNull();
+    });
+  });
+
+  describe("delete_goal", () => {
+    it("should delete a goal", async () => {
+      const goal = await Goal.create({
+        userId,
+        name: "To Delete",
+        targetAmount: 100,
+      });
+
+      await Goal.findOneAndDelete({ _id: goal._id, userId });
+      const found = await Goal.findById(goal._id);
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("add_goal_funds", () => {
+    it("should add funds to a goal", async () => {
+      const goal = await Goal.create({
+        userId,
+        name: "Savings",
+        targetAmount: 1000,
+        currentAmount: 200,
+      });
+
+      goal.currentAmount += 300;
+      await goal.save();
+
+      const updated = await Goal.findById(goal._id);
+      expect(updated!.currentAmount).toBe(500);
+      expect(updated!.isCompleted).toBe(false);
+    });
+
+    it("should auto-complete goal when target is reached", async () => {
+      const goal = await Goal.create({
+        userId,
+        name: "Almost Done",
+        targetAmount: 1000,
+        currentAmount: 900,
+      });
+
+      goal.currentAmount += 200;
+      if (goal.currentAmount >= goal.targetAmount) {
+        goal.isCompleted = true;
+      }
+      await goal.save();
+
+      const updated = await Goal.findById(goal._id);
+      expect(updated!.currentAmount).toBe(1100);
+      expect(updated!.isCompleted).toBe(true);
+    });
+
+    it("should reject adding funds to completed goal", async () => {
+      const goal = await Goal.create({
+        userId,
+        name: "Completed",
+        targetAmount: 1000,
+        currentAmount: 1000,
+        isCompleted: true,
+      });
+
+      expect(goal.isCompleted).toBe(true);
+    });
+  });
+});

--- a/mcp/src/__tests__/tools/recurring.tool.test.ts
+++ b/mcp/src/__tests__/tools/recurring.tool.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import mongoose from "mongoose";
+import { RecurringRule } from "../../models/recurring-rule.model";
+import { Transaction } from "../../models/transaction.model";
+import { Account } from "../../models/account.model";
+import { Category } from "../../models/category.model";
+
+const userId = new mongoose.Types.ObjectId().toString();
+
+async function createTestData() {
+  const account = await Account.create({
+    userId,
+    name: "Main",
+    type: "checking",
+    balance: 5000,
+  });
+  const category = await Category.create({
+    name: "Bills",
+    icon: "B",
+    color: "#000",
+    type: "expense",
+    isDefault: true,
+  });
+  return { account, category };
+}
+
+describe("recurring tools", () => {
+  describe("list_recurring", () => {
+    it("should list all recurring rules for user", async () => {
+      const { account, category } = await createTestData();
+      const startDate = new Date(2024, 0, 1);
+
+      await RecurringRule.create({
+        userId,
+        accountId: account._id,
+        categoryId: category._id,
+        type: "expense",
+        amount: 100,
+        description: "Netflix",
+        frequency: "monthly",
+        startDate,
+        nextDueDate: startDate,
+      });
+
+      const rules = await RecurringRule.find({ userId });
+      expect(rules).toHaveLength(1);
+      expect(rules[0].description).toBe("Netflix");
+    });
+  });
+
+  describe("create_recurring", () => {
+    it("should create a recurring rule with nextDueDate = startDate", async () => {
+      const { account, category } = await createTestData();
+      const startDate = new Date(2024, 5, 1);
+
+      const rule = await RecurringRule.create({
+        userId,
+        accountId: account._id,
+        categoryId: category._id,
+        type: "expense",
+        amount: 50,
+        description: "Gym",
+        frequency: "monthly",
+        startDate,
+        nextDueDate: startDate,
+      });
+
+      expect(rule.nextDueDate.getTime()).toBe(startDate.getTime());
+      expect(rule.isActive).toBe(true);
+    });
+  });
+
+  describe("get_upcoming_bills", () => {
+    it("should return rules due within 30 days", async () => {
+      const { account, category } = await createTestData();
+      const now = new Date();
+      const soon = new Date();
+      soon.setDate(soon.getDate() + 10);
+      const far = new Date();
+      far.setDate(far.getDate() + 60);
+
+      await RecurringRule.create({
+        userId,
+        accountId: account._id,
+        categoryId: category._id,
+        type: "expense",
+        amount: 100,
+        description: "Due soon",
+        frequency: "monthly",
+        startDate: now,
+        nextDueDate: soon,
+      });
+      await RecurringRule.create({
+        userId,
+        accountId: account._id,
+        categoryId: category._id,
+        type: "expense",
+        amount: 200,
+        description: "Due later",
+        frequency: "monthly",
+        startDate: now,
+        nextDueDate: far,
+      });
+
+      const thirtyDays = new Date();
+      thirtyDays.setDate(thirtyDays.getDate() + 30);
+
+      const upcoming = await RecurringRule.find({
+        userId,
+        isActive: true,
+        nextDueDate: { $gte: now, $lte: thirtyDays },
+      });
+
+      expect(upcoming).toHaveLength(1);
+      expect(upcoming[0].description).toBe("Due soon");
+    });
+  });
+
+  describe("mark_recurring_paid", () => {
+    it("should create transaction and advance nextDueDate", async () => {
+      const { account, category } = await createTestData();
+      const nextDue = new Date(2024, 5, 1);
+
+      const rule = await RecurringRule.create({
+        userId,
+        accountId: account._id,
+        categoryId: category._id,
+        type: "expense",
+        amount: 100,
+        description: "Netflix",
+        frequency: "monthly",
+        startDate: nextDue,
+        nextDueDate: nextDue,
+      });
+
+      // Simulate mark as paid
+      const tx = await Transaction.create({
+        userId: rule.userId,
+        accountId: rule.accountId,
+        type: rule.type,
+        amount: rule.amount,
+        currency: account.currency,
+        categoryId: rule.categoryId,
+        description: rule.description,
+        date: rule.nextDueDate,
+        isRecurring: true,
+        recurringRuleId: rule._id,
+        tags: [],
+      });
+
+      await Account.findByIdAndUpdate(account._id, {
+        $inc: { balance: -rule.amount },
+      });
+
+      const newNext = new Date(rule.nextDueDate);
+      newNext.setMonth(newNext.getMonth() + 1);
+      rule.nextDueDate = newNext;
+      await rule.save();
+
+      expect(tx.isRecurring).toBe(true);
+      expect(tx.recurringRuleId!.toString()).toBe(rule._id.toString());
+
+      const updatedRule = await RecurringRule.findById(rule._id);
+      expect(updatedRule!.nextDueDate.getMonth()).toBe(6); // July
+
+      const updatedAccount = await Account.findById(account._id);
+      expect(updatedAccount!.balance).toBe(4900);
+    });
+
+    it("should deactivate rule when nextDueDate passes endDate", async () => {
+      const { account, category } = await createTestData();
+      const nextDue = new Date(2024, 11, 1);
+      const endDate = new Date(2024, 11, 31);
+
+      const rule = await RecurringRule.create({
+        userId,
+        accountId: account._id,
+        categoryId: category._id,
+        type: "expense",
+        amount: 50,
+        description: "Trial sub",
+        frequency: "monthly",
+        startDate: nextDue,
+        nextDueDate: nextDue,
+        endDate,
+      });
+
+      const newNext = new Date(nextDue);
+      newNext.setMonth(newNext.getMonth() + 1); // Jan 2025
+
+      if (rule.endDate && newNext > rule.endDate) {
+        rule.isActive = false;
+      }
+      rule.nextDueDate = newNext;
+      await rule.save();
+
+      expect(rule.isActive).toBe(false);
+    });
+  });
+
+  describe("delete_recurring", () => {
+    it("should delete a recurring rule", async () => {
+      const { account, category } = await createTestData();
+
+      const rule = await RecurringRule.create({
+        userId,
+        accountId: account._id,
+        categoryId: category._id,
+        type: "expense",
+        amount: 100,
+        description: "To Delete",
+        frequency: "weekly",
+        startDate: new Date(),
+        nextDueDate: new Date(),
+      });
+
+      await RecurringRule.findOneAndDelete({ _id: rule._id, userId });
+      const found = await RecurringRule.findById(rule._id);
+      expect(found).toBeNull();
+    });
+  });
+});

--- a/mcp/src/__tests__/tools/transactions.tool.test.ts
+++ b/mcp/src/__tests__/tools/transactions.tool.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect } from "vitest";
+import mongoose from "mongoose";
+import { Account } from "../../models/account.model";
+import { Transaction } from "../../models/transaction.model";
+import { Category } from "../../models/category.model";
+
+const userId = new mongoose.Types.ObjectId().toString();
+
+async function createTestAccount(balance = 1000) {
+  return Account.create({
+    userId,
+    name: "Test Checking",
+    type: "checking",
+    balance,
+  });
+}
+
+async function createTestCategory(type: "income" | "expense" = "expense") {
+  return Category.create({
+    name: "Test Cat",
+    icon: "T",
+    color: "#000",
+    type,
+    isDefault: true,
+  });
+}
+
+describe("transactions tools", () => {
+  describe("list_transactions", () => {
+    it("should list transactions with pagination", async () => {
+      const account = await createTestAccount();
+      const category = await createTestCategory();
+
+      for (let i = 0; i < 5; i++) {
+        await Transaction.create({
+          userId,
+          accountId: account._id,
+          type: "expense",
+          amount: 100 + i,
+          categoryId: category._id,
+          description: `Expense ${i}`,
+          date: new Date(2024, 0, i + 1),
+        });
+      }
+
+      const transactions = await Transaction.find({ userId })
+        .sort({ date: -1 })
+        .skip(0)
+        .limit(3);
+      const total = await Transaction.countDocuments({ userId });
+
+      expect(transactions).toHaveLength(3);
+      expect(total).toBe(5);
+    });
+
+    it("should filter by type", async () => {
+      const account = await createTestAccount();
+      const category = await createTestCategory();
+      const incomeCategory = await createTestCategory("income");
+
+      await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 50,
+        categoryId: category._id,
+        description: "Expense",
+        date: new Date(),
+      });
+      await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "income",
+        amount: 200,
+        categoryId: incomeCategory._id,
+        description: "Income",
+        date: new Date(),
+      });
+
+      const expenses = await Transaction.find({ userId, type: "expense" });
+      expect(expenses).toHaveLength(1);
+      expect(expenses[0].description).toBe("Expense");
+    });
+
+    it("should filter by date range", async () => {
+      const account = await createTestAccount();
+      const category = await createTestCategory();
+
+      await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 100,
+        categoryId: category._id,
+        description: "Jan",
+        date: new Date(2024, 0, 15),
+      });
+      await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 200,
+        categoryId: category._id,
+        description: "Mar",
+        date: new Date(2024, 2, 15),
+      });
+
+      const filtered = await Transaction.find({
+        userId,
+        date: { $gte: new Date(2024, 1, 1), $lte: new Date(2024, 2, 31) },
+      });
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].description).toBe("Mar");
+    });
+  });
+
+  describe("search_transactions", () => {
+    it("should search by description regex", async () => {
+      const account = await createTestAccount();
+      const category = await createTestCategory();
+
+      await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 50,
+        categoryId: category._id,
+        description: "Grocery at Walmart",
+        date: new Date(),
+      });
+      await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 30,
+        categoryId: category._id,
+        description: "Gas station",
+        date: new Date(),
+      });
+
+      const results = await Transaction.find({
+        userId,
+        description: { $regex: "grocery", $options: "i" },
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].description).toBe("Grocery at Walmart");
+    });
+  });
+
+  describe("create_transaction", () => {
+    it("should create a transaction and adjust account balance", async () => {
+      const account = await createTestAccount(1000);
+      const category = await createTestCategory();
+
+      const tx = await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 200,
+        categoryId: category._id,
+        description: "Dinner",
+        date: new Date(),
+      });
+
+      await Account.findByIdAndUpdate(account._id, {
+        $inc: { balance: -200 },
+      });
+
+      expect(tx.amount).toBe(200);
+      const updated = await Account.findById(account._id);
+      expect(updated!.balance).toBe(800);
+    });
+
+    it("should increase balance for income transactions", async () => {
+      const account = await createTestAccount(1000);
+      const category = await createTestCategory("income");
+
+      await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "income",
+        amount: 500,
+        categoryId: category._id,
+        description: "Freelance",
+        date: new Date(),
+      });
+
+      await Account.findByIdAndUpdate(account._id, {
+        $inc: { balance: 500 },
+      });
+
+      const updated = await Account.findById(account._id);
+      expect(updated!.balance).toBe(1500);
+    });
+  });
+
+  describe("get_transaction", () => {
+    it("should get a transaction by ID with ownership check", async () => {
+      const account = await createTestAccount();
+      const category = await createTestCategory();
+      const tx = await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 100,
+        categoryId: category._id,
+        description: "Test",
+        date: new Date(),
+      });
+
+      const found = await Transaction.findOne({ _id: tx._id, userId });
+      expect(found).not.toBeNull();
+      expect(found!.description).toBe("Test");
+    });
+
+    it("should not find transaction of another user", async () => {
+      const otherUserId = new mongoose.Types.ObjectId();
+      const account = await Account.create({
+        userId: otherUserId,
+        name: "Other",
+        type: "checking",
+      });
+      const category = await createTestCategory();
+      const tx = await Transaction.create({
+        userId: otherUserId,
+        accountId: account._id,
+        type: "expense",
+        amount: 100,
+        categoryId: category._id,
+        description: "Other",
+        date: new Date(),
+      });
+
+      const found = await Transaction.findOne({ _id: tx._id, userId });
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("update_transaction", () => {
+    it("should update transaction fields", async () => {
+      const account = await createTestAccount();
+      const category = await createTestCategory();
+      const tx = await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 100,
+        categoryId: category._id,
+        description: "Old",
+        date: new Date(),
+      });
+
+      const updated = await Transaction.findOneAndUpdate(
+        { _id: tx._id, userId },
+        { $set: { description: "New", amount: 200 } },
+        { new: true },
+      );
+      expect(updated!.description).toBe("New");
+      expect(updated!.amount).toBe(200);
+    });
+  });
+
+  describe("delete_transaction", () => {
+    it("should delete a transaction and it no longer exists", async () => {
+      const account = await createTestAccount();
+      const category = await createTestCategory();
+      const tx = await Transaction.create({
+        userId,
+        accountId: account._id,
+        type: "expense",
+        amount: 100,
+        categoryId: category._id,
+        description: "To delete",
+        date: new Date(),
+      });
+
+      await Transaction.findOneAndDelete({ _id: tx._id, userId });
+      const found = await Transaction.findById(tx._id);
+      expect(found).toBeNull();
+    });
+  });
+});

--- a/mcp/src/auth/token-resolver.ts
+++ b/mcp/src/auth/token-resolver.ts
@@ -1,0 +1,38 @@
+import jwt from "jsonwebtoken";
+import { getEnv } from "../config/env";
+import { McpToolError } from "../utils/errors";
+
+interface JwtPayload {
+  userId: string;
+  iat?: number;
+  exp?: number;
+}
+
+export function resolveUserId(transport: string, token?: string): string {
+  const env = getEnv();
+
+  if (transport === "stdio") {
+    const userId = process.env.MCP_USER_ID;
+    if (!userId) {
+      throw McpToolError.unauthorized(
+        "MCP_USER_ID must be set when using stdio transport"
+      );
+    }
+    return userId;
+  }
+
+  if (!token) {
+    throw McpToolError.unauthorized("Authorization token is required");
+  }
+
+  try {
+    const decoded = jwt.verify(token, env.JWT_SECRET) as JwtPayload;
+    if (!decoded.userId) {
+      throw McpToolError.unauthorized("Invalid token: missing userId");
+    }
+    return decoded.userId;
+  } catch (error) {
+    if (error instanceof McpToolError) throw error;
+    throw McpToolError.unauthorized("Invalid or expired token");
+  }
+}

--- a/mcp/src/config/env.ts
+++ b/mcp/src/config/env.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  MONGODB_URI: z.string().min(1, "MONGODB_URI is required"),
+  JWT_SECRET: z.string().min(32, "JWT_SECRET must be at least 32 characters"),
+  MCP_PORT: z.coerce.number().default(5100),
+  MCP_TRANSPORT: z.enum(["sse", "stdio"]).default("sse"),
+  MCP_USER_ID: z.string().optional(),
+  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+let cachedEnv: Env | null = null;
+
+export function validateEnv(): Env {
+  if (cachedEnv) return cachedEnv;
+  const result = envSchema.safeParse(process.env);
+  if (!result.success) {
+    const formatted = result.error.issues
+      .map((i) => `  ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+    throw new Error(`Environment validation failed:\n${formatted}`);
+  }
+  cachedEnv = result.data;
+  return cachedEnv;
+}
+
+export function getEnv(): Env {
+  if (!cachedEnv) {
+    return validateEnv();
+  }
+  return cachedEnv;
+}

--- a/mcp/src/db/connection.ts
+++ b/mcp/src/db/connection.ts
@@ -1,0 +1,22 @@
+import mongoose from "mongoose";
+import { logger } from "../utils/logger";
+
+export async function connectDatabase(uri: string): Promise<void> {
+  try {
+    await mongoose.connect(uri);
+    logger.info("Connected to MongoDB");
+  } catch (error) {
+    logger.error({ error }, "Failed to connect to MongoDB");
+    throw error;
+  }
+}
+
+export async function disconnectDatabase(): Promise<void> {
+  try {
+    await mongoose.disconnect();
+    logger.info("Disconnected from MongoDB");
+  } catch (error) {
+    logger.error({ error }, "Failed to disconnect from MongoDB");
+    throw error;
+  }
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,38 @@
+import { validateEnv } from "./config/env";
+import { connectDatabase, disconnectDatabase } from "./db/connection";
+import { createMcpServer } from "./server";
+import { startStdioTransport } from "./transport/stdio";
+import { startSseTransport } from "./transport/sse";
+import { resolveUserId } from "./auth/token-resolver";
+import { logger } from "./utils/logger";
+
+async function main(): Promise<void> {
+  const env = validateEnv();
+
+  await connectDatabase(env.MONGODB_URI);
+
+  const { server, setUserId } = createMcpServer();
+
+  if (env.MCP_TRANSPORT === "stdio") {
+    const userId = resolveUserId("stdio");
+    setUserId(userId);
+    await startStdioTransport(server);
+  } else {
+    startSseTransport(server, env.MCP_PORT, setUserId);
+  }
+
+  const shutdown = async () => {
+    logger.info("Shutting down MCP server...");
+    await server.close();
+    await disconnectDatabase();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+main().catch((error) => {
+  logger.error({ error }, "Failed to start MCP server");
+  process.exit(1);
+});

--- a/mcp/src/models/account.model.ts
+++ b/mcp/src/models/account.model.ts
@@ -1,0 +1,62 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+export interface IAccount extends Document {
+  _id: mongoose.Types.ObjectId;
+  userId: mongoose.Types.ObjectId;
+  name: string;
+  type: "checking" | "savings" | "credit_card" | "cash" | "investment";
+  balance: number;
+  currency: string;
+  color: string;
+  isArchived: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const accountSchema = new Schema<IAccount>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: [true, "User ID is required"],
+      index: true,
+    },
+    name: {
+      type: String,
+      required: [true, "Account name is required"],
+      trim: true,
+      minlength: 1,
+      maxlength: 50,
+    },
+    type: {
+      type: String,
+      required: [true, "Account type is required"],
+      enum: ["checking", "savings", "credit_card", "cash", "investment"],
+    },
+    balance: {
+      type: Number,
+      default: 0,
+    },
+    currency: {
+      type: String,
+      default: "USD",
+      minlength: 3,
+      maxlength: 3,
+    },
+    color: {
+      type: String,
+      default: "#6366f1",
+    },
+    isArchived: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+accountSchema.index({ userId: 1, isArchived: 1 });
+
+export const Account = mongoose.model<IAccount>("Account", accountSchema);

--- a/mcp/src/models/budget.model.ts
+++ b/mcp/src/models/budget.model.ts
@@ -1,0 +1,56 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+export interface IBudget extends Document {
+  _id: mongoose.Types.ObjectId;
+  userId: mongoose.Types.ObjectId;
+  categoryId: mongoose.Types.ObjectId;
+  amount: number;
+  period: "monthly" | "weekly";
+  alertThreshold: number;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const budgetSchema = new Schema<IBudget>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: [true, "User ID is required"],
+      index: true,
+    },
+    categoryId: {
+      type: Schema.Types.ObjectId,
+      ref: "Category",
+      required: [true, "Category ID is required"],
+    },
+    amount: {
+      type: Number,
+      required: [true, "Budget amount is required"],
+      min: [0, "Budget amount must be positive"],
+    },
+    period: {
+      type: String,
+      required: [true, "Budget period is required"],
+      enum: ["monthly", "weekly"],
+    },
+    alertThreshold: {
+      type: Number,
+      default: 0.8,
+      min: 0,
+      max: 1,
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+budgetSchema.index({ userId: 1, categoryId: 1 });
+
+export const Budget = mongoose.model<IBudget>("Budget", budgetSchema);

--- a/mcp/src/models/category.model.ts
+++ b/mcp/src/models/category.model.ts
@@ -1,0 +1,55 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+export interface ICategory extends Document {
+  _id: mongoose.Types.ObjectId;
+  userId: mongoose.Types.ObjectId | null;
+  name: string;
+  icon: string;
+  color: string;
+  type: "income" | "expense";
+  isDefault: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const categorySchema = new Schema<ICategory>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      default: null,
+    },
+    name: {
+      type: String,
+      required: [true, "Category name is required"],
+      trim: true,
+      minlength: 1,
+      maxlength: 30,
+    },
+    icon: {
+      type: String,
+      required: [true, "Icon is required"],
+      trim: true,
+    },
+    color: {
+      type: String,
+      required: [true, "Color is required"],
+    },
+    type: {
+      type: String,
+      required: [true, "Category type is required"],
+      enum: ["income", "expense"],
+    },
+    isDefault: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+categorySchema.index({ userId: 1, type: 1 });
+
+export const Category = mongoose.model<ICategory>("Category", categorySchema);

--- a/mcp/src/models/goal.model.ts
+++ b/mcp/src/models/goal.model.ts
@@ -1,0 +1,64 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+export interface IGoal extends Document {
+  _id: mongoose.Types.ObjectId;
+  userId: mongoose.Types.ObjectId;
+  name: string;
+  targetAmount: number;
+  currentAmount: number;
+  deadline?: Date;
+  color: string;
+  icon: string;
+  isCompleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const goalSchema = new Schema<IGoal>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: [true, "User ID is required"],
+      index: true,
+    },
+    name: {
+      type: String,
+      required: [true, "Goal name is required"],
+      trim: true,
+      minlength: 1,
+      maxlength: 50,
+    },
+    targetAmount: {
+      type: Number,
+      required: [true, "Target amount is required"],
+      min: [0, "Target amount must be positive"],
+    },
+    currentAmount: {
+      type: Number,
+      default: 0,
+      min: [0, "Current amount cannot be negative"],
+    },
+    deadline: {
+      type: Date,
+      default: null,
+    },
+    color: {
+      type: String,
+      default: "#10b981",
+    },
+    icon: {
+      type: String,
+      default: "\uD83C\uDFAF",
+    },
+    isCompleted: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+export const Goal = mongoose.model<IGoal>("Goal", goalSchema);

--- a/mcp/src/models/recurring-rule.model.ts
+++ b/mcp/src/models/recurring-rule.model.ts
@@ -1,0 +1,86 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+export interface IRecurringRule extends Document {
+  _id: mongoose.Types.ObjectId;
+  userId: mongoose.Types.ObjectId;
+  accountId: mongoose.Types.ObjectId;
+  categoryId: mongoose.Types.ObjectId;
+  type: "income" | "expense";
+  amount: number;
+  description: string;
+  frequency: "daily" | "weekly" | "biweekly" | "monthly" | "yearly";
+  startDate: Date;
+  nextDueDate: Date;
+  endDate?: Date;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const recurringRuleSchema = new Schema<IRecurringRule>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: [true, "User ID is required"],
+      index: true,
+    },
+    accountId: {
+      type: Schema.Types.ObjectId,
+      ref: "Account",
+      required: [true, "Account ID is required"],
+    },
+    categoryId: {
+      type: Schema.Types.ObjectId,
+      ref: "Category",
+      required: [true, "Category ID is required"],
+    },
+    type: {
+      type: String,
+      required: [true, "Type is required"],
+      enum: ["income", "expense"],
+    },
+    amount: {
+      type: Number,
+      required: [true, "Amount is required"],
+      min: [0, "Amount must be positive"],
+    },
+    description: {
+      type: String,
+      required: [true, "Description is required"],
+      trim: true,
+      maxlength: 200,
+    },
+    frequency: {
+      type: String,
+      required: [true, "Frequency is required"],
+      enum: ["daily", "weekly", "biweekly", "monthly", "yearly"],
+    },
+    startDate: {
+      type: Date,
+      required: [true, "Start date is required"],
+    },
+    nextDueDate: {
+      type: Date,
+      required: [true, "Next due date is required"],
+    },
+    endDate: {
+      type: Date,
+      default: null,
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+recurringRuleSchema.index({ userId: 1, isActive: 1, nextDueDate: 1 });
+
+export const RecurringRule = mongoose.model<IRecurringRule>(
+  "RecurringRule",
+  recurringRuleSchema,
+);

--- a/mcp/src/models/transaction.model.ts
+++ b/mcp/src/models/transaction.model.ts
@@ -1,0 +1,102 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+export interface ITransaction extends Document {
+  _id: mongoose.Types.ObjectId;
+  userId: mongoose.Types.ObjectId;
+  accountId: mongoose.Types.ObjectId;
+  type: "income" | "expense" | "transfer";
+  amount: number;
+  currency: string;
+  categoryId: mongoose.Types.ObjectId;
+  subcategory?: string;
+  description: string;
+  notes?: string;
+  date: Date;
+  isRecurring: boolean;
+  recurringRuleId?: mongoose.Types.ObjectId;
+  tags: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const transactionSchema = new Schema<ITransaction>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: [true, "User ID is required"],
+    },
+    accountId: {
+      type: Schema.Types.ObjectId,
+      ref: "Account",
+      required: [true, "Account ID is required"],
+    },
+    type: {
+      type: String,
+      required: [true, "Transaction type is required"],
+      enum: ["income", "expense", "transfer"],
+    },
+    amount: {
+      type: Number,
+      required: [true, "Amount is required"],
+      min: [0, "Amount must be positive"],
+    },
+    currency: {
+      type: String,
+      default: "USD",
+      minlength: 3,
+      maxlength: 3,
+    },
+    categoryId: {
+      type: Schema.Types.ObjectId,
+      ref: "Category",
+      required: [true, "Category ID is required"],
+    },
+    subcategory: {
+      type: String,
+      trim: true,
+      default: null,
+    },
+    description: {
+      type: String,
+      required: [true, "Description is required"],
+      trim: true,
+      maxlength: 200,
+    },
+    notes: {
+      type: String,
+      trim: true,
+      default: null,
+    },
+    date: {
+      type: Date,
+      required: [true, "Date is required"],
+    },
+    isRecurring: {
+      type: Boolean,
+      default: false,
+    },
+    recurringRuleId: {
+      type: Schema.Types.ObjectId,
+      ref: "RecurringRule",
+      default: null,
+    },
+    tags: {
+      type: [String],
+      default: [],
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+transactionSchema.index({ userId: 1, date: -1 });
+transactionSchema.index({ userId: 1, categoryId: 1, date: -1 });
+transactionSchema.index({ userId: 1, accountId: 1, date: -1 });
+transactionSchema.index({ description: "text" });
+
+export const Transaction = mongoose.model<ITransaction>(
+  "Transaction",
+  transactionSchema,
+);

--- a/mcp/src/models/user.model.ts
+++ b/mcp/src/models/user.model.ts
@@ -1,0 +1,51 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+export interface IUser extends Document {
+  _id: mongoose.Types.ObjectId;
+  email: string;
+  name: string;
+  passwordHash: string;
+  avatarUrl?: string;
+  currency: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const userSchema = new Schema<IUser>(
+  {
+    email: {
+      type: String,
+      required: [true, "Email is required"],
+      unique: true,
+      lowercase: true,
+      trim: true,
+      index: true,
+    },
+    name: {
+      type: String,
+      required: [true, "Name is required"],
+      trim: true,
+      minlength: [2, "Name must be at least 2 characters"],
+      maxlength: [50, "Name must be at most 50 characters"],
+    },
+    passwordHash: {
+      type: String,
+      required: [true, "Password hash is required"],
+    },
+    avatarUrl: {
+      type: String,
+      default: null,
+    },
+    currency: {
+      type: String,
+      default: "USD",
+      minlength: 3,
+      maxlength: 3,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+export const User = mongoose.model<IUser>("User", userSchema);

--- a/mcp/src/resources/budget-status.ts
+++ b/mcp/src/resources/budget-status.ts
@@ -1,0 +1,86 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import mongoose from "mongoose";
+import { Budget } from "../models/budget.model";
+import { Transaction } from "../models/transaction.model";
+
+function getPeriodStartDate(period: "monthly" | "weekly"): Date {
+  const now = new Date();
+  if (period === "monthly") {
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+  }
+  const day = now.getDay();
+  const diff = day === 0 ? 6 : day - 1;
+  const monday = new Date(now);
+  monday.setDate(now.getDate() - diff);
+  monday.setHours(0, 0, 0, 0);
+  return monday;
+}
+
+export function registerBudgetStatusResource(
+  server: McpServer,
+  getUserId: () => string,
+) {
+  server.resource(
+    "budget-status",
+    "wealthwise://budget-status",
+    "Active budgets with spent and remaining amounts",
+    async () => {
+      const userId = getUserId();
+      const budgets = await Budget.find({ userId, isActive: true });
+
+      const summaries = await Promise.all(
+        budgets.map(async (budget) => {
+          const periodStart = getPeriodStartDate(budget.period);
+          const now = new Date();
+
+          const result = await Transaction.aggregate([
+            {
+              $match: {
+                userId: new mongoose.Types.ObjectId(userId),
+                categoryId: budget.categoryId,
+                type: "expense",
+                date: { $gte: periodStart, $lte: now },
+              },
+            },
+            {
+              $group: {
+                _id: null,
+                totalSpent: { $sum: "$amount" },
+              },
+            },
+          ]);
+
+          const spent = result.length > 0 ? result[0].totalSpent : 0;
+          const percentage =
+            budget.amount > 0 ? spent / budget.amount : 0;
+
+          let status: string;
+          if (percentage >= 1) status = "over_budget";
+          else if (percentage >= budget.alertThreshold) status = "warning";
+          else status = "under_budget";
+
+          return {
+            id: budget._id.toString(),
+            categoryId: budget.categoryId.toString(),
+            amount: budget.amount,
+            period: budget.period,
+            spent,
+            remaining: Math.max(0, budget.amount - spent),
+            percentage: Math.round(percentage * 10000) / 10000,
+            status,
+          };
+        }),
+      );
+
+      return {
+        contents: [
+          {
+            uri: "wealthwise://budget-status",
+            text: JSON.stringify(summaries),
+            mimeType: "application/json",
+          },
+        ],
+      };
+    },
+  );
+}

--- a/mcp/src/resources/financial-summary.ts
+++ b/mcp/src/resources/financial-summary.ts
@@ -1,0 +1,78 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import mongoose from "mongoose";
+import { Account } from "../models/account.model";
+import { Transaction } from "../models/transaction.model";
+
+export function registerFinancialSummaryResource(
+  server: McpServer,
+  getUserId: () => string,
+) {
+  server.resource(
+    "financial-summary",
+    "wealthwise://summary",
+    "Current month income, expenses, savings rate, and account balances",
+    async () => {
+      const userId = getUserId();
+      const now = new Date();
+      const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+      const [accounts, monthlyAgg] = await Promise.all([
+        Account.find({ userId, isArchived: false }),
+        Transaction.aggregate([
+          {
+            $match: {
+              userId: new mongoose.Types.ObjectId(userId),
+              type: { $in: ["income", "expense"] },
+              date: { $gte: startOfMonth, $lte: now },
+            },
+          },
+          {
+            $group: {
+              _id: "$type",
+              total: { $sum: "$amount" },
+            },
+          },
+        ]),
+      ]);
+
+      let income = 0;
+      let expense = 0;
+      for (const r of monthlyAgg) {
+        if (r._id === "income") income = r.total;
+        if (r._id === "expense") expense = r.total;
+      }
+
+      const savings = income - expense;
+      const savingsRate =
+        income > 0
+          ? Math.round((savings / income) * 10000) / 100
+          : 0;
+
+      const summary = {
+        month: `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`,
+        totalIncome: income,
+        totalExpenses: expense,
+        netSavings: savings,
+        savingsRate,
+        accounts: accounts.map((a) => ({
+          id: a._id.toString(),
+          name: a.name,
+          type: a.type,
+          balance: a.balance,
+          currency: a.currency,
+        })),
+        totalBalance: accounts.reduce((sum, a) => sum + a.balance, 0),
+      };
+
+      return {
+        contents: [
+          {
+            uri: "wealthwise://summary",
+            text: JSON.stringify(summary),
+            mimeType: "application/json",
+          },
+        ],
+      };
+    },
+  );
+}

--- a/mcp/src/resources/goal-progress.ts
+++ b/mcp/src/resources/goal-progress.ts
@@ -1,0 +1,42 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Goal } from "../models/goal.model";
+
+export function registerGoalProgressResource(
+  server: McpServer,
+  getUserId: () => string,
+) {
+  server.resource(
+    "goal-progress",
+    "wealthwise://goal-progress",
+    "All savings goals with percentage complete",
+    async () => {
+      const userId = getUserId();
+      const goals = await Goal.find({ userId }).sort({ createdAt: -1 });
+
+      const progress = goals.map((g) => ({
+        id: g._id.toString(),
+        name: g.name,
+        targetAmount: g.targetAmount,
+        currentAmount: g.currentAmount,
+        percentComplete:
+          g.targetAmount > 0
+            ? Math.round((g.currentAmount / g.targetAmount) * 10000) / 100
+            : 0,
+        deadline: g.deadline ? g.deadline.toISOString() : null,
+        isCompleted: g.isCompleted,
+        color: g.color,
+        icon: g.icon,
+      }));
+
+      return {
+        contents: [
+          {
+            uri: "wealthwise://goal-progress",
+            text: JSON.stringify(progress),
+            mimeType: "application/json",
+          },
+        ],
+      };
+    },
+  );
+}

--- a/mcp/src/resources/index.ts
+++ b/mcp/src/resources/index.ts
@@ -1,0 +1,15 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerFinancialSummaryResource } from "./financial-summary";
+import { registerBudgetStatusResource } from "./budget-status";
+import { registerGoalProgressResource } from "./goal-progress";
+import { registerUpcomingBillsResource } from "./upcoming-bills";
+
+export function registerAllResources(
+  server: McpServer,
+  getUserId: () => string,
+): void {
+  registerFinancialSummaryResource(server, getUserId);
+  registerBudgetStatusResource(server, getUserId);
+  registerGoalProgressResource(server, getUserId);
+  registerUpcomingBillsResource(server, getUserId);
+}

--- a/mcp/src/resources/upcoming-bills.ts
+++ b/mcp/src/resources/upcoming-bills.ts
@@ -1,0 +1,46 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { RecurringRule } from "../models/recurring-rule.model";
+
+export function registerUpcomingBillsResource(
+  server: McpServer,
+  getUserId: () => string,
+) {
+  server.resource(
+    "upcoming-bills",
+    "wealthwise://upcoming-bills",
+    "Recurring payments due within the next 30 days",
+    async () => {
+      const userId = getUserId();
+      const now = new Date();
+      const thirtyDays = new Date();
+      thirtyDays.setDate(thirtyDays.getDate() + 30);
+
+      const rules = await RecurringRule.find({
+        userId,
+        isActive: true,
+        nextDueDate: { $gte: now, $lte: thirtyDays },
+      }).sort({ nextDueDate: 1 });
+
+      const bills = rules.map((r) => ({
+        id: r._id.toString(),
+        description: r.description,
+        amount: r.amount,
+        type: r.type,
+        frequency: r.frequency,
+        nextDueDate: r.nextDueDate.toISOString(),
+        accountId: r.accountId.toString(),
+        categoryId: r.categoryId.toString(),
+      }));
+
+      return {
+        contents: [
+          {
+            uri: "wealthwise://upcoming-bills",
+            text: JSON.stringify(bills),
+            mimeType: "application/json",
+          },
+        ],
+      };
+    },
+  );
+}

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,0 +1,34 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAllTools } from "./tools";
+import { registerAllResources } from "./resources";
+
+export interface ServerContext {
+  server: McpServer;
+  getUserId: () => string;
+  setUserId: (id: string) => void;
+}
+
+export function createMcpServer(): ServerContext {
+  let currentUserId = "";
+
+  const getUserId = (): string => {
+    if (!currentUserId) {
+      throw new Error("No authenticated user. userId is not set.");
+    }
+    return currentUserId;
+  };
+
+  const setUserId = (id: string): void => {
+    currentUserId = id;
+  };
+
+  const server = new McpServer({
+    name: "wealthwise-mcp",
+    version: "1.0.0",
+  });
+
+  registerAllTools(server, getUserId);
+  registerAllResources(server, getUserId);
+
+  return { server, getUserId, setUserId };
+}

--- a/mcp/src/tools/accounts.tool.ts
+++ b/mcp/src/tools/accounts.tool.ts
@@ -1,0 +1,217 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import mongoose from "mongoose";
+import { Account, IAccount } from "../models/account.model";
+import { Transaction } from "../models/transaction.model";
+import { McpToolError } from "../utils/errors";
+
+function formatAccount(account: IAccount) {
+  return {
+    id: account._id.toString(),
+    userId: account.userId.toString(),
+    name: account.name,
+    type: account.type,
+    balance: account.balance,
+    currency: account.currency,
+    color: account.color,
+    isArchived: account.isArchived,
+    createdAt: account.createdAt.toISOString(),
+    updatedAt: account.updatedAt.toISOString(),
+  };
+}
+
+function textResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+export function registerAccountTools(
+  server: McpServer,
+  getUserId: () => string,
+) {
+  server.tool(
+    "list_accounts",
+    "List all non-archived accounts for the user, sorted by creation date descending",
+    {},
+    async () => {
+      const userId = getUserId();
+      const accounts = await Account.find({
+        userId,
+        isArchived: false,
+      }).sort({ createdAt: -1 });
+      return textResult(accounts.map(formatAccount));
+    },
+  );
+
+  server.tool(
+    "get_account",
+    "Get a single account by ID, verifying ownership",
+    { accountId: z.string().describe("The account ID to retrieve") },
+    async ({ accountId }) => {
+      const userId = getUserId();
+      const account = await Account.findOne({ _id: accountId, userId });
+      if (!account) throw McpToolError.notFound("Account not found");
+      return textResult(formatAccount(account));
+    },
+  );
+
+  server.tool(
+    "create_account",
+    "Create a new financial account",
+    {
+      name: z.string().describe("Account name"),
+      type: z
+        .enum(["checking", "savings", "credit_card", "cash", "investment"])
+        .describe("Account type"),
+      balance: z.number().optional().describe("Initial balance (default 0)"),
+      currency: z
+        .string()
+        .length(3)
+        .optional()
+        .describe("Currency code (default USD)"),
+      color: z.string().optional().describe("Color hex code"),
+    },
+    async ({ name, type, balance, currency, color }) => {
+      const userId = getUserId();
+      const account = await Account.create({
+        userId,
+        name,
+        type,
+        balance,
+        currency,
+        color,
+      });
+      return textResult(formatAccount(account));
+    },
+  );
+
+  server.tool(
+    "update_account",
+    "Update an existing account, verifying ownership",
+    {
+      accountId: z.string().describe("The account ID to update"),
+      name: z.string().optional().describe("New account name"),
+      type: z
+        .enum(["checking", "savings", "credit_card", "cash", "investment"])
+        .optional()
+        .describe("New account type"),
+      balance: z.number().optional().describe("New balance"),
+      currency: z
+        .string()
+        .length(3)
+        .optional()
+        .describe("New currency code"),
+      color: z.string().optional().describe("New color hex code"),
+    },
+    async ({ accountId, ...data }) => {
+      const userId = getUserId();
+      const updateData: Record<string, unknown> = {};
+      if (data.name !== undefined) updateData.name = data.name;
+      if (data.type !== undefined) updateData.type = data.type;
+      if (data.balance !== undefined) updateData.balance = data.balance;
+      if (data.currency !== undefined) updateData.currency = data.currency;
+      if (data.color !== undefined) updateData.color = data.color;
+
+      const account = await Account.findOneAndUpdate(
+        { _id: accountId, userId },
+        { $set: updateData },
+        { new: true, runValidators: true },
+      );
+      if (!account) throw McpToolError.notFound("Account not found");
+      return textResult(formatAccount(account));
+    },
+  );
+
+  server.tool(
+    "archive_account",
+    "Soft-delete (archive) an account, verifying ownership",
+    { accountId: z.string().describe("The account ID to archive") },
+    async ({ accountId }) => {
+      const userId = getUserId();
+      const account = await Account.findOneAndUpdate(
+        { _id: accountId, userId },
+        { $set: { isArchived: true } },
+        { new: true },
+      );
+      if (!account) throw McpToolError.notFound("Account not found");
+      return textResult(formatAccount(account));
+    },
+  );
+
+  server.tool(
+    "get_balance_history",
+    "Get monthly balance snapshots for an account from transaction aggregation",
+    { accountId: z.string().describe("The account ID") },
+    async ({ accountId }) => {
+      const userId = getUserId();
+      const account = await Account.findOne({ _id: accountId, userId });
+      if (!account) throw McpToolError.notFound("Account not found");
+
+      const pipeline = [
+        {
+          $match: {
+            accountId: new mongoose.Types.ObjectId(accountId),
+            userId: new mongoose.Types.ObjectId(userId),
+          },
+        },
+        {
+          $group: {
+            _id: {
+              year: { $year: "$date" },
+              month: { $month: "$date" },
+            },
+            income: {
+              $sum: {
+                $cond: [{ $eq: ["$type", "income"] }, "$amount", 0],
+              },
+            },
+            expense: {
+              $sum: {
+                $cond: [{ $eq: ["$type", "expense"] }, "$amount", 0],
+              },
+            },
+          },
+        },
+        {
+          $sort: {
+            "_id.year": 1 as const,
+            "_id.month": 1 as const,
+          },
+        },
+        {
+          $project: {
+            _id: 0,
+            year: "$_id.year",
+            month: "$_id.month",
+            income: 1,
+            expense: 1,
+            net: { $subtract: ["$income", "$expense"] },
+          },
+        },
+      ];
+
+      const history = await Transaction.aggregate(pipeline);
+
+      let runningBalance = 0;
+      const balanceHistory = history.map(
+        (entry: {
+          year: number;
+          month: number;
+          income: number;
+          expense: number;
+          net: number;
+        }) => {
+          runningBalance += entry.net;
+          return {
+            year: entry.year,
+            month: entry.month,
+            balance: runningBalance,
+            income: entry.income,
+            expense: entry.expense,
+          };
+        },
+      );
+
+      return textResult(balanceHistory);
+    },
+  );
+}

--- a/mcp/src/tools/analytics.tool.ts
+++ b/mcp/src/tools/analytics.tool.ts
@@ -1,0 +1,560 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import mongoose from "mongoose";
+import { Transaction } from "../models/transaction.model";
+import { Account } from "../models/account.model";
+
+function textResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+export function registerAnalyticsTools(
+  server: McpServer,
+  getUserId: () => string,
+) {
+  server.tool(
+    "spending_by_category",
+    "Get spending breakdown by category for a date range, with percentages",
+    {
+      startDate: z.string().describe("Start date (ISO string)"),
+      endDate: z.string().describe("End date (ISO string)"),
+    },
+    async ({ startDate, endDate }) => {
+      const userId = getUserId();
+      const pipeline = [
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: "expense",
+            date: { $gte: new Date(startDate), $lte: new Date(endDate) },
+          },
+        },
+        {
+          $group: {
+            _id: "$categoryId",
+            total: { $sum: "$amount" },
+            count: { $sum: 1 },
+          },
+        },
+        {
+          $lookup: {
+            from: "categories",
+            localField: "_id",
+            foreignField: "_id",
+            as: "category",
+          },
+        },
+        { $unwind: "$category" },
+        {
+          $project: {
+            _id: 0,
+            categoryId: { $toString: "$_id" },
+            categoryName: "$category.name",
+            categoryIcon: "$category.icon",
+            categoryColor: "$category.color",
+            total: 1,
+            count: 1,
+          },
+        },
+        { $sort: { total: -1 as const } },
+      ];
+
+      const results = await Transaction.aggregate(pipeline);
+      const grandTotal = results.reduce(
+        (sum: number, r: { total: number }) => sum + r.total,
+        0,
+      );
+
+      return textResult(
+        results.map(
+          (r: {
+            categoryId: string;
+            categoryName: string;
+            categoryIcon: string;
+            categoryColor: string;
+            total: number;
+            count: number;
+          }) => ({
+            categoryId: r.categoryId,
+            categoryName: r.categoryName,
+            categoryIcon: r.categoryIcon,
+            categoryColor: r.categoryColor,
+            amount: r.total,
+            transactionCount: r.count,
+            percentage:
+              grandTotal > 0
+                ? Math.round((r.total / grandTotal) * 10000) / 100
+                : 0,
+          }),
+        ),
+      );
+    },
+  );
+
+  server.tool(
+    "income_vs_expense",
+    "Get monthly income vs expense comparison for the last N months",
+    {
+      months: z
+        .number()
+        .int()
+        .positive()
+        .describe("Number of months to look back"),
+    },
+    async ({ months }) => {
+      const userId = getUserId();
+      const startDate = new Date();
+      startDate.setMonth(startDate.getMonth() - months);
+      startDate.setDate(1);
+      startDate.setHours(0, 0, 0, 0);
+
+      const pipeline = [
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: { $in: ["income", "expense"] },
+            date: { $gte: startDate },
+          },
+        },
+        {
+          $group: {
+            _id: {
+              year: { $year: "$date" },
+              month: { $month: "$date" },
+              type: "$type",
+            },
+            total: { $sum: "$amount" },
+          },
+        },
+        {
+          $sort: {
+            "_id.year": 1 as const,
+            "_id.month": 1 as const,
+          },
+        },
+      ];
+
+      const raw = await Transaction.aggregate(pipeline);
+      const monthlyMap = new Map<
+        string,
+        { year: number; month: number; income: number; expense: number }
+      >();
+
+      for (const entry of raw) {
+        const key = `${entry._id.year}-${entry._id.month}`;
+        if (!monthlyMap.has(key)) {
+          monthlyMap.set(key, {
+            year: entry._id.year,
+            month: entry._id.month,
+            income: 0,
+            expense: 0,
+          });
+        }
+        const record = monthlyMap.get(key)!;
+        if (entry._id.type === "income") {
+          record.income = entry.total;
+        } else {
+          record.expense = entry.total;
+        }
+      }
+
+      const result = Array.from(monthlyMap.values())
+        .sort((a, b) =>
+          a.year !== b.year ? a.year - b.year : a.month - b.month,
+        )
+        .map((entry) => ({
+          month: `${entry.year}-${String(entry.month).padStart(2, "0")}`,
+          income: entry.income,
+          expense: entry.expense,
+          net: entry.income - entry.expense,
+        }));
+
+      return textResult(result);
+    },
+  );
+
+  server.tool(
+    "monthly_summary",
+    "Get total income, expenses, savings, and savings rate for a specific month",
+    {
+      year: z.number().int().describe("Year (e.g. 2024)"),
+      month: z.number().int().min(1).max(12).describe("Month (1-12)"),
+    },
+    async ({ year, month }) => {
+      const userId = getUserId();
+      const startDate = new Date(year, month - 1, 1);
+      const endDate = new Date(year, month, 0, 23, 59, 59, 999);
+
+      const pipeline = [
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: { $in: ["income", "expense"] },
+            date: { $gte: startDate, $lte: endDate },
+          },
+        },
+        {
+          $group: {
+            _id: "$type",
+            total: { $sum: "$amount" },
+            count: { $sum: 1 },
+          },
+        },
+      ];
+
+      const results = await Transaction.aggregate(pipeline);
+
+      let income = 0;
+      let expense = 0;
+      let incomeCount = 0;
+      let expenseCount = 0;
+
+      for (const r of results) {
+        if (r._id === "income") {
+          income = r.total;
+          incomeCount = r.count;
+        } else if (r._id === "expense") {
+          expense = r.total;
+          expenseCount = r.count;
+        }
+      }
+
+      const savings = income - expense;
+      const savingsRate =
+        income > 0
+          ? Math.round((savings / income) * 10000) / 100
+          : 0;
+
+      return textResult({
+        totalIncome: income,
+        totalExpenses: expense,
+        netSavings: savings,
+        savingsRate,
+        transactionCount: incomeCount + expenseCount,
+      });
+    },
+  );
+
+  server.tool(
+    "get_trends",
+    "Get monthly income, expense, and savings rate trends over N months",
+    {
+      months: z
+        .number()
+        .int()
+        .positive()
+        .describe("Number of months to analyze"),
+    },
+    async ({ months }) => {
+      const userId = getUserId();
+      const startDate = new Date();
+      startDate.setMonth(startDate.getMonth() - months);
+      startDate.setDate(1);
+      startDate.setHours(0, 0, 0, 0);
+
+      const pipeline = [
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: { $in: ["income", "expense"] },
+            date: { $gte: startDate },
+          },
+        },
+        {
+          $group: {
+            _id: {
+              year: { $year: "$date" },
+              month: { $month: "$date" },
+              type: "$type",
+            },
+            total: { $sum: "$amount" },
+          },
+        },
+        {
+          $sort: {
+            "_id.year": 1 as const,
+            "_id.month": 1 as const,
+          },
+        },
+      ];
+
+      const raw = await Transaction.aggregate(pipeline);
+      const monthlyMap = new Map<
+        string,
+        { year: number; month: number; income: number; expense: number }
+      >();
+
+      for (const entry of raw) {
+        const key = `${entry._id.year}-${entry._id.month}`;
+        if (!monthlyMap.has(key)) {
+          monthlyMap.set(key, {
+            year: entry._id.year,
+            month: entry._id.month,
+            income: 0,
+            expense: 0,
+          });
+        }
+        const record = monthlyMap.get(key)!;
+        if (entry._id.type === "income") {
+          record.income = entry.total;
+        } else {
+          record.expense = entry.total;
+        }
+      }
+
+      const sorted = Array.from(monthlyMap.values()).sort((a, b) =>
+        a.year !== b.year ? a.year - b.year : a.month - b.month,
+      );
+
+      let runningNetWorth = 0;
+      const result = sorted.map((entry) => {
+        const net = entry.income - entry.expense;
+        runningNetWorth += net;
+        const savingsRate =
+          entry.income > 0
+            ? Math.round((net / entry.income) * 10000) / 100
+            : 0;
+        return {
+          month: `${entry.year}-${String(entry.month).padStart(2, "0")}`,
+          income: entry.income,
+          expense: entry.expense,
+          savingsRate,
+          netWorth: runningNetWorth,
+        };
+      });
+
+      return textResult(result);
+    },
+  );
+
+  server.tool(
+    "spending_by_day_of_week",
+    "Get average spending patterns by day of the week",
+    {
+      startDate: z.string().describe("Start date (ISO string)"),
+      endDate: z.string().describe("End date (ISO string)"),
+    },
+    async ({ startDate, endDate }) => {
+      const userId = getUserId();
+      const pipeline = [
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: "expense",
+            date: { $gte: new Date(startDate), $lte: new Date(endDate) },
+          },
+        },
+        {
+          $group: {
+            _id: { $dayOfWeek: "$date" },
+            total: { $sum: "$amount" },
+            count: { $sum: 1 },
+          },
+        },
+        { $sort: { _id: 1 as const } },
+      ];
+
+      const results = await Transaction.aggregate(pipeline);
+      const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+      return textResult(
+        dayNames.map((name, index) => {
+          const found = results.find(
+            (r: { _id: number }) => r._id === index + 1,
+          );
+          return {
+            day: name,
+            total: found ? found.total : 0,
+            count: found ? found.count : 0,
+            average:
+              found && found.count > 0
+                ? Math.round((found.total / found.count) * 100) / 100
+                : 0,
+          };
+        }),
+      );
+    },
+  );
+
+  server.tool(
+    "category_monthly_breakdown",
+    "Get expense breakdown by top categories per month over N months",
+    {
+      months: z
+        .number()
+        .int()
+        .positive()
+        .describe("Number of months to analyze"),
+    },
+    async ({ months }) => {
+      const userId = getUserId();
+      const startDate = new Date();
+      startDate.setMonth(startDate.getMonth() - months);
+      startDate.setDate(1);
+      startDate.setHours(0, 0, 0, 0);
+
+      const pipeline = [
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+            type: "expense",
+            date: { $gte: startDate },
+          },
+        },
+        {
+          $group: {
+            _id: {
+              year: { $year: "$date" },
+              month: { $month: "$date" },
+              categoryId: "$categoryId",
+            },
+            total: { $sum: "$amount" },
+          },
+        },
+        {
+          $lookup: {
+            from: "categories",
+            localField: "_id.categoryId",
+            foreignField: "_id",
+            as: "category",
+          },
+        },
+        { $unwind: "$category" },
+        {
+          $sort: {
+            "_id.year": 1 as const,
+            "_id.month": 1 as const,
+            total: -1 as const,
+          },
+        },
+        {
+          $project: {
+            _id: 0,
+            year: "$_id.year",
+            month: "$_id.month",
+            categoryName: "$category.name",
+            categoryColor: "$category.color",
+            total: 1,
+          },
+        },
+      ];
+
+      const results = await Transaction.aggregate(pipeline);
+
+      const categoryTotals = new Map<string, number>();
+      for (const r of results) {
+        categoryTotals.set(
+          r.categoryName,
+          (categoryTotals.get(r.categoryName) ?? 0) + r.total,
+        );
+      }
+      const topCategories = Array.from(categoryTotals.entries())
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 6)
+        .map(([name]) => name);
+
+      const colorMap = new Map<string, string>();
+      for (const r of results) {
+        if (!colorMap.has(r.categoryName)) {
+          colorMap.set(r.categoryName, r.categoryColor);
+        }
+      }
+
+      const monthlyMap = new Map<string, Record<string, number | string>>();
+      for (const r of results) {
+        const key = `${r.year}-${String(r.month).padStart(2, "0")}`;
+        if (!monthlyMap.has(key)) {
+          monthlyMap.set(key, { month: key });
+        }
+        const record = monthlyMap.get(key)!;
+        if (topCategories.includes(r.categoryName)) {
+          record[r.categoryName] =
+            ((record[r.categoryName] as number) ?? 0) + r.total;
+        } else {
+          record["Other"] = ((record["Other"] as number) ?? 0) + r.total;
+        }
+      }
+
+      return textResult({
+        months: Array.from(monthlyMap.values()).sort((a, b) =>
+          (a.month as string).localeCompare(b.month as string),
+        ),
+        categories: topCategories,
+        colors: Object.fromEntries(
+          topCategories.map((name) => [
+            name,
+            colorMap.get(name) ?? "#94a3b8",
+          ]),
+        ),
+      });
+    },
+  );
+
+  server.tool(
+    "get_net_worth",
+    "Get net worth progression over time from all transaction history",
+    {},
+    async () => {
+      const userId = getUserId();
+      const accounts = await Account.find({ userId });
+      if (accounts.length === 0) return textResult([]);
+
+      const pipeline = [
+        {
+          $match: {
+            userId: new mongoose.Types.ObjectId(userId),
+          },
+        },
+        {
+          $group: {
+            _id: {
+              year: { $year: "$date" },
+              month: { $month: "$date" },
+            },
+            income: {
+              $sum: {
+                $cond: [{ $eq: ["$type", "income"] }, "$amount", 0],
+              },
+            },
+            expense: {
+              $sum: {
+                $cond: [{ $eq: ["$type", "expense"] }, "$amount", 0],
+              },
+            },
+          },
+        },
+        {
+          $sort: {
+            "_id.year": 1 as const,
+            "_id.month": 1 as const,
+          },
+        },
+        {
+          $project: {
+            _id: 0,
+            year: "$_id.year",
+            month: "$_id.month",
+            income: 1,
+            expense: 1,
+            net: { $subtract: ["$income", "$expense"] },
+          },
+        },
+      ];
+
+      const monthly = await Transaction.aggregate(pipeline);
+
+      let runningTotal = 0;
+      return textResult(
+        monthly.map(
+          (entry: { year: number; month: number; net: number }) => {
+            runningTotal += entry.net;
+            return {
+              date: `${entry.year}-${String(entry.month).padStart(2, "0")}`,
+              amount: runningTotal,
+            };
+          },
+        ),
+      );
+    },
+  );
+}

--- a/mcp/src/tools/budgets.tool.ts
+++ b/mcp/src/tools/budgets.tool.ts
@@ -1,0 +1,174 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import mongoose from "mongoose";
+import { Budget, IBudget } from "../models/budget.model";
+import { Transaction } from "../models/transaction.model";
+import { McpToolError } from "../utils/errors";
+
+function formatBudget(budget: IBudget) {
+  return {
+    id: budget._id.toString(),
+    userId: budget.userId.toString(),
+    categoryId: budget.categoryId.toString(),
+    amount: budget.amount,
+    period: budget.period,
+    alertThreshold: budget.alertThreshold,
+    isActive: budget.isActive,
+    createdAt: budget.createdAt.toISOString(),
+    updatedAt: budget.updatedAt.toISOString(),
+  };
+}
+
+function textResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+function getPeriodStartDate(period: "monthly" | "weekly"): Date {
+  const now = new Date();
+  if (period === "monthly") {
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+  }
+  const day = now.getDay();
+  const diff = day === 0 ? 6 : day - 1;
+  const monday = new Date(now);
+  monday.setDate(now.getDate() - diff);
+  monday.setHours(0, 0, 0, 0);
+  return monday;
+}
+
+export function registerBudgetTools(
+  server: McpServer,
+  getUserId: () => string,
+) {
+  server.tool(
+    "list_budgets",
+    "List all budgets for the user",
+    {},
+    async () => {
+      const userId = getUserId();
+      const budgets = await Budget.find({ userId }).sort({ createdAt: -1 });
+      return textResult(budgets.map(formatBudget));
+    },
+  );
+
+  server.tool(
+    "create_budget",
+    "Create a new budget for a spending category",
+    {
+      categoryId: z.string().describe("Category ID to budget"),
+      amount: z.number().positive().describe("Budget amount"),
+      period: z.enum(["monthly", "weekly"]).describe("Budget period"),
+      alertThreshold: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe("Alert threshold (0-1, default 0.8)"),
+    },
+    async (params) => {
+      const userId = getUserId();
+      const budget = await Budget.create({
+        userId,
+        categoryId: params.categoryId,
+        amount: params.amount,
+        period: params.period,
+        alertThreshold: params.alertThreshold,
+      });
+      return textResult(formatBudget(budget));
+    },
+  );
+
+  server.tool(
+    "update_budget",
+    "Update an existing budget, verifying ownership",
+    {
+      budgetId: z.string().describe("The budget ID to update"),
+      categoryId: z.string().optional().describe("New category ID"),
+      amount: z.number().positive().optional().describe("New amount"),
+      period: z
+        .enum(["monthly", "weekly"])
+        .optional()
+        .describe("New period"),
+      alertThreshold: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe("New alert threshold"),
+    },
+    async ({ budgetId, ...data }) => {
+      const userId = getUserId();
+      const updateData: Record<string, unknown> = {};
+      if (data.categoryId !== undefined) updateData.categoryId = data.categoryId;
+      if (data.amount !== undefined) updateData.amount = data.amount;
+      if (data.period !== undefined) updateData.period = data.period;
+      if (data.alertThreshold !== undefined)
+        updateData.alertThreshold = data.alertThreshold;
+
+      const budget = await Budget.findOneAndUpdate(
+        { _id: budgetId, userId },
+        { $set: updateData },
+        { new: true, runValidators: true },
+      );
+      if (!budget) throw McpToolError.notFound("Budget not found");
+      return textResult(formatBudget(budget));
+    },
+  );
+
+  server.tool(
+    "get_budget_summary",
+    "Get active budgets with spent amount, remaining, and status for the current period",
+    {},
+    async () => {
+      const userId = getUserId();
+      const budgets = await Budget.find({ userId, isActive: true });
+
+      const summaries = await Promise.all(
+        budgets.map(async (budget) => {
+          const periodStart = getPeriodStartDate(budget.period);
+          const now = new Date();
+
+          const result = await Transaction.aggregate([
+            {
+              $match: {
+                userId: new mongoose.Types.ObjectId(userId),
+                categoryId: budget.categoryId,
+                type: "expense",
+                date: { $gte: periodStart, $lte: now },
+              },
+            },
+            {
+              $group: {
+                _id: null,
+                totalSpent: { $sum: "$amount" },
+              },
+            },
+          ]);
+
+          const spent = result.length > 0 ? result[0].totalSpent : 0;
+          const percentage =
+            budget.amount > 0 ? spent / budget.amount : 0;
+
+          let status: "under_budget" | "warning" | "over_budget";
+          if (percentage >= 1) {
+            status = "over_budget";
+          } else if (percentage >= budget.alertThreshold) {
+            status = "warning";
+          } else {
+            status = "under_budget";
+          }
+
+          return {
+            ...formatBudget(budget),
+            spent,
+            remaining: Math.max(0, budget.amount - spent),
+            percentage: Math.round(percentage * 10000) / 10000,
+            status,
+          };
+        }),
+      );
+
+      return textResult(summaries);
+    },
+  );
+}

--- a/mcp/src/tools/categories.tool.ts
+++ b/mcp/src/tools/categories.tool.ts
@@ -1,0 +1,68 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { Category } from "../models/category.model";
+
+function textResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+function formatCategory(cat: {
+  _id: { toString(): string };
+  userId?: { toString(): string } | null;
+  name: string;
+  icon: string;
+  color: string;
+  type: string;
+  isDefault: boolean;
+}) {
+  return {
+    id: cat._id.toString(),
+    userId: cat.userId ? cat.userId.toString() : null,
+    name: cat.name,
+    icon: cat.icon,
+    color: cat.color,
+    type: cat.type,
+    isDefault: cat.isDefault,
+  };
+}
+
+export function registerCategoryTools(
+  server: McpServer,
+  getUserId: () => string,
+) {
+  server.tool(
+    "list_categories",
+    "List user categories and system default categories",
+    {},
+    async () => {
+      const userId = getUserId();
+      const categories = await Category.find({
+        $or: [{ userId }, { userId: null }],
+      }).sort({ type: 1, name: 1 });
+      return textResult(categories.map(formatCategory));
+    },
+  );
+
+  server.tool(
+    "create_category",
+    "Create a custom spending or income category",
+    {
+      name: z.string().max(30).describe("Category name"),
+      icon: z.string().describe("Emoji icon"),
+      color: z.string().describe("Color hex code"),
+      type: z.enum(["income", "expense"]).describe("Category type"),
+    },
+    async (params) => {
+      const userId = getUserId();
+      const category = await Category.create({
+        userId,
+        name: params.name,
+        icon: params.icon,
+        color: params.color,
+        type: params.type,
+        isDefault: false,
+      });
+      return textResult(formatCategory(category));
+    },
+  );
+}

--- a/mcp/src/tools/goals.tool.ts
+++ b/mcp/src/tools/goals.tool.ts
@@ -1,0 +1,149 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { Goal, IGoal } from "../models/goal.model";
+import { McpToolError } from "../utils/errors";
+
+function formatGoal(goal: IGoal) {
+  return {
+    id: goal._id.toString(),
+    userId: goal.userId.toString(),
+    name: goal.name,
+    targetAmount: goal.targetAmount,
+    currentAmount: goal.currentAmount,
+    deadline: goal.deadline ? goal.deadline.toISOString() : null,
+    color: goal.color,
+    icon: goal.icon,
+    isCompleted: goal.isCompleted,
+    createdAt: goal.createdAt.toISOString(),
+    updatedAt: goal.updatedAt.toISOString(),
+  };
+}
+
+function textResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+export function registerGoalTools(
+  server: McpServer,
+  getUserId: () => string,
+) {
+  server.tool(
+    "list_goals",
+    "List all savings goals for the user",
+    {},
+    async () => {
+      const userId = getUserId();
+      const goals = await Goal.find({ userId }).sort({ createdAt: -1 });
+      return textResult(goals.map(formatGoal));
+    },
+  );
+
+  server.tool(
+    "create_goal",
+    "Create a new savings goal",
+    {
+      name: z.string().max(50).describe("Goal name"),
+      targetAmount: z.number().positive().describe("Target amount"),
+      currentAmount: z
+        .number()
+        .min(0)
+        .optional()
+        .describe("Current amount (default 0)"),
+      deadline: z
+        .string()
+        .optional()
+        .describe("Deadline date (ISO string)"),
+      color: z.string().optional().describe("Color hex code"),
+      icon: z.string().optional().describe("Emoji icon"),
+    },
+    async (params) => {
+      const userId = getUserId();
+      const goal = await Goal.create({
+        userId,
+        name: params.name,
+        targetAmount: params.targetAmount,
+        currentAmount: params.currentAmount ?? 0,
+        deadline: params.deadline ? new Date(params.deadline) : null,
+        color: params.color,
+        icon: params.icon,
+      });
+      return textResult(formatGoal(goal));
+    },
+  );
+
+  server.tool(
+    "update_goal",
+    "Update a savings goal, verifying ownership",
+    {
+      goalId: z.string().describe("The goal ID to update"),
+      name: z.string().max(50).optional().describe("New name"),
+      targetAmount: z.number().positive().optional().describe("New target"),
+      currentAmount: z
+        .number()
+        .min(0)
+        .optional()
+        .describe("New current amount"),
+      deadline: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("New deadline (ISO string or null)"),
+      color: z.string().optional().describe("New color"),
+      icon: z.string().optional().describe("New icon"),
+    },
+    async ({ goalId, ...data }) => {
+      const userId = getUserId();
+      const updateData: Record<string, unknown> = { ...data };
+      if (data.deadline !== undefined) {
+        updateData.deadline = data.deadline
+          ? new Date(data.deadline)
+          : null;
+      }
+
+      const goal = await Goal.findOneAndUpdate(
+        { _id: goalId, userId },
+        { $set: updateData },
+        { new: true, runValidators: true },
+      );
+      if (!goal) throw McpToolError.notFound("Goal not found");
+      return textResult(formatGoal(goal));
+    },
+  );
+
+  server.tool(
+    "delete_goal",
+    "Delete a savings goal, verifying ownership",
+    { goalId: z.string().describe("The goal ID to delete") },
+    async ({ goalId }) => {
+      const userId = getUserId();
+      const goal = await Goal.findOneAndDelete({ _id: goalId, userId });
+      if (!goal) throw McpToolError.notFound("Goal not found");
+      return textResult(formatGoal(goal));
+    },
+  );
+
+  server.tool(
+    "add_goal_funds",
+    "Add funds to a savings goal, auto-completing if target is reached",
+    {
+      goalId: z.string().describe("The goal ID"),
+      amount: z.number().positive().describe("Amount to add"),
+    },
+    async ({ goalId, amount }) => {
+      const userId = getUserId();
+      const goal = await Goal.findOne({ _id: goalId, userId });
+      if (!goal) throw McpToolError.notFound("Goal not found");
+      if (goal.isCompleted) {
+        throw McpToolError.badRequest("This goal is already completed");
+      }
+
+      goal.currentAmount += amount;
+      if (goal.currentAmount >= goal.targetAmount) {
+        goal.isCompleted = true;
+      }
+      await goal.save();
+
+      return textResult(formatGoal(goal));
+    },
+  );
+}

--- a/mcp/src/tools/index.ts
+++ b/mcp/src/tools/index.ts
@@ -1,0 +1,21 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAccountTools } from "./accounts.tool";
+import { registerTransactionTools } from "./transactions.tool";
+import { registerBudgetTools } from "./budgets.tool";
+import { registerGoalTools } from "./goals.tool";
+import { registerCategoryTools } from "./categories.tool";
+import { registerRecurringTools } from "./recurring.tool";
+import { registerAnalyticsTools } from "./analytics.tool";
+
+export function registerAllTools(
+  server: McpServer,
+  getUserId: () => string,
+): void {
+  registerAccountTools(server, getUserId);
+  registerTransactionTools(server, getUserId);
+  registerBudgetTools(server, getUserId);
+  registerGoalTools(server, getUserId);
+  registerCategoryTools(server, getUserId);
+  registerRecurringTools(server, getUserId);
+  registerAnalyticsTools(server, getUserId);
+}

--- a/mcp/src/tools/recurring.tool.ts
+++ b/mcp/src/tools/recurring.tool.ts
@@ -1,0 +1,213 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { RecurringRule, IRecurringRule } from "../models/recurring-rule.model";
+import { Transaction } from "../models/transaction.model";
+import { Account } from "../models/account.model";
+import { McpToolError } from "../utils/errors";
+
+function formatRule(rule: IRecurringRule) {
+  return {
+    id: rule._id.toString(),
+    userId: rule.userId.toString(),
+    accountId: rule.accountId.toString(),
+    categoryId: rule.categoryId.toString(),
+    type: rule.type,
+    amount: rule.amount,
+    description: rule.description,
+    frequency: rule.frequency,
+    startDate: rule.startDate.toISOString(),
+    nextDueDate: rule.nextDueDate.toISOString(),
+    endDate: rule.endDate ? rule.endDate.toISOString() : null,
+    isActive: rule.isActive,
+    createdAt: rule.createdAt.toISOString(),
+    updatedAt: rule.updatedAt.toISOString(),
+  };
+}
+
+function advanceDate(current: Date, frequency: string): Date {
+  const next = new Date(current);
+  switch (frequency) {
+    case "daily":
+      next.setDate(next.getDate() + 1);
+      break;
+    case "weekly":
+      next.setDate(next.getDate() + 7);
+      break;
+    case "biweekly":
+      next.setDate(next.getDate() + 14);
+      break;
+    case "monthly":
+      next.setMonth(next.getMonth() + 1);
+      break;
+    case "yearly":
+      next.setFullYear(next.getFullYear() + 1);
+      break;
+    default:
+      next.setMonth(next.getMonth() + 1);
+  }
+  return next;
+}
+
+function textResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+export function registerRecurringTools(
+  server: McpServer,
+  getUserId: () => string,
+) {
+  server.tool(
+    "list_recurring",
+    "List all recurring rules for the user",
+    {},
+    async () => {
+      const userId = getUserId();
+      const rules = await RecurringRule.find({ userId }).sort({
+        nextDueDate: 1,
+      });
+      return textResult(rules.map(formatRule));
+    },
+  );
+
+  server.tool(
+    "create_recurring",
+    "Create a new recurring transaction rule",
+    {
+      accountId: z.string().describe("Account ID"),
+      categoryId: z.string().describe("Category ID"),
+      type: z.enum(["income", "expense"]).describe("Transaction type"),
+      amount: z.number().positive().describe("Amount"),
+      description: z.string().max(200).describe("Description"),
+      frequency: z
+        .enum(["daily", "weekly", "biweekly", "monthly", "yearly"])
+        .describe("Recurrence frequency"),
+      startDate: z.string().describe("Start date (ISO string)"),
+      endDate: z
+        .string()
+        .optional()
+        .describe("End date (ISO string, optional)"),
+    },
+    async (params) => {
+      const userId = getUserId();
+      const account = await Account.findOne({
+        _id: params.accountId,
+        userId,
+      });
+      if (!account) throw McpToolError.notFound("Account not found");
+
+      const rule = await RecurringRule.create({
+        userId,
+        accountId: params.accountId,
+        categoryId: params.categoryId,
+        type: params.type,
+        amount: params.amount,
+        description: params.description,
+        frequency: params.frequency,
+        startDate: new Date(params.startDate),
+        nextDueDate: new Date(params.startDate),
+        endDate: params.endDate ? new Date(params.endDate) : null,
+      });
+
+      return textResult(formatRule(rule));
+    },
+  );
+
+  server.tool(
+    "get_upcoming_bills",
+    "Get recurring payments due within the next 30 days",
+    {},
+    async () => {
+      const userId = getUserId();
+      const now = new Date();
+      const thirtyDays = new Date();
+      thirtyDays.setDate(thirtyDays.getDate() + 30);
+
+      const rules = await RecurringRule.find({
+        userId,
+        isActive: true,
+        nextDueDate: { $gte: now, $lte: thirtyDays },
+      }).sort({ nextDueDate: 1 });
+
+      return textResult(rules.map(formatRule));
+    },
+  );
+
+  server.tool(
+    "mark_recurring_paid",
+    "Mark a recurring rule as paid: creates a transaction and advances the due date",
+    { ruleId: z.string().describe("The recurring rule ID") },
+    async ({ ruleId }) => {
+      const userId = getUserId();
+      const rule = await RecurringRule.findOne({ _id: ruleId, userId });
+      if (!rule) throw McpToolError.notFound("Recurring rule not found");
+
+      if (!rule.isActive) {
+        throw McpToolError.badRequest(
+          "This recurring rule is no longer active",
+        );
+      }
+
+      const account = await Account.findOne({
+        _id: rule.accountId,
+        userId,
+      });
+      if (!account) {
+        throw McpToolError.notFound(
+          "The account associated with this rule was not found",
+        );
+      }
+
+      const transaction = await Transaction.create({
+        userId: rule.userId,
+        accountId: rule.accountId,
+        type: rule.type,
+        amount: rule.amount,
+        currency: account.currency,
+        categoryId: rule.categoryId,
+        description: rule.description,
+        date: rule.nextDueDate,
+        isRecurring: true,
+        recurringRuleId: rule._id,
+        tags: [],
+      });
+
+      const balanceDelta =
+        rule.type === "income" ? rule.amount : -rule.amount;
+      await Account.findByIdAndUpdate(rule.accountId, {
+        $inc: { balance: balanceDelta },
+      });
+
+      const newNextDueDate = advanceDate(rule.nextDueDate, rule.frequency);
+      if (rule.endDate && newNextDueDate > rule.endDate) {
+        rule.isActive = false;
+      }
+      rule.nextDueDate = newNextDueDate;
+      await rule.save();
+
+      return textResult({
+        rule: formatRule(rule),
+        transaction: {
+          id: transaction._id.toString(),
+          description: transaction.description,
+          amount: transaction.amount,
+          date: transaction.date.toISOString(),
+        },
+      });
+    },
+  );
+
+  server.tool(
+    "delete_recurring",
+    "Delete a recurring rule, verifying ownership",
+    { ruleId: z.string().describe("The recurring rule ID to delete") },
+    async ({ ruleId }) => {
+      const userId = getUserId();
+      const rule = await RecurringRule.findOneAndDelete({
+        _id: ruleId,
+        userId,
+      });
+      if (!rule) throw McpToolError.notFound("Recurring rule not found");
+      return textResult(formatRule(rule));
+    },
+  );
+}

--- a/mcp/src/tools/transactions.tool.ts
+++ b/mcp/src/tools/transactions.tool.ts
@@ -1,0 +1,301 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { Transaction, ITransaction } from "../models/transaction.model";
+import { Account } from "../models/account.model";
+import { McpToolError } from "../utils/errors";
+
+function formatTransaction(tx: ITransaction) {
+  return {
+    id: tx._id.toString(),
+    userId: tx.userId.toString(),
+    accountId: tx.accountId.toString(),
+    type: tx.type,
+    amount: tx.amount,
+    currency: tx.currency,
+    categoryId: tx.categoryId.toString(),
+    subcategory: tx.subcategory ?? null,
+    description: tx.description,
+    notes: tx.notes ?? null,
+    date: tx.date.toISOString(),
+    isRecurring: tx.isRecurring,
+    recurringRuleId: tx.recurringRuleId?.toString() ?? null,
+    tags: tx.tags,
+    createdAt: tx.createdAt.toISOString(),
+    updatedAt: tx.updatedAt.toISOString(),
+  };
+}
+
+function textResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+async function adjustAccountBalance(
+  accountId: string,
+  type: string,
+  amount: number,
+  operation: "add" | "remove",
+) {
+  let delta = 0;
+  if (type === "income") {
+    delta = operation === "add" ? amount : -amount;
+  } else if (type === "expense") {
+    delta = operation === "add" ? -amount : amount;
+  }
+  if (delta !== 0) {
+    await Account.findByIdAndUpdate(accountId, { $inc: { balance: delta } });
+  }
+}
+
+export function registerTransactionTools(
+  server: McpServer,
+  getUserId: () => string,
+) {
+  server.tool(
+    "list_transactions",
+    "List transactions with filtering, sorting, and pagination",
+    {
+      page: z.number().int().positive().optional().describe("Page number (default 1)"),
+      limit: z.number().int().positive().max(100).optional().describe("Items per page (default 20)"),
+      accountId: z.string().optional().describe("Filter by account ID"),
+      categoryId: z.string().optional().describe("Filter by category ID"),
+      type: z.enum(["income", "expense", "transfer"]).optional().describe("Filter by type"),
+      startDate: z.string().optional().describe("Filter from date (ISO string)"),
+      endDate: z.string().optional().describe("Filter to date (ISO string)"),
+      minAmount: z.number().optional().describe("Minimum amount filter"),
+      maxAmount: z.number().optional().describe("Maximum amount filter"),
+      sortBy: z.string().optional().describe("Sort field (default: date)"),
+      sortOrder: z.enum(["asc", "desc"]).optional().describe("Sort direction (default: desc)"),
+    },
+    async (params) => {
+      const userId = getUserId();
+      const page = params.page ?? 1;
+      const limit = params.limit ?? 20;
+      const skip = (page - 1) * limit;
+
+      const query: Record<string, unknown> = { userId };
+      if (params.accountId) query.accountId = params.accountId;
+      if (params.categoryId) query.categoryId = params.categoryId;
+      if (params.type) query.type = params.type;
+      if (params.startDate || params.endDate) {
+        const dateFilter: Record<string, Date> = {};
+        if (params.startDate) dateFilter.$gte = new Date(params.startDate);
+        if (params.endDate) dateFilter.$lte = new Date(params.endDate);
+        query.date = dateFilter;
+      }
+      if (params.minAmount !== undefined || params.maxAmount !== undefined) {
+        const amountFilter: Record<string, number> = {};
+        if (params.minAmount !== undefined) amountFilter.$gte = params.minAmount;
+        if (params.maxAmount !== undefined) amountFilter.$lte = params.maxAmount;
+        query.amount = amountFilter;
+      }
+
+      const sortField = params.sortBy ?? "date";
+      const sortDirection = params.sortOrder === "asc" ? 1 : -1;
+
+      const [transactions, total] = await Promise.all([
+        Transaction.find(query)
+          .sort({ [sortField]: sortDirection })
+          .skip(skip)
+          .limit(limit),
+        Transaction.countDocuments(query),
+      ]);
+
+      return textResult({
+        data: transactions.map(formatTransaction),
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+        },
+      });
+    },
+  );
+
+  server.tool(
+    "search_transactions",
+    "Search transactions by description using regex matching",
+    {
+      query: z.string().describe("Search query for description"),
+      page: z.number().int().positive().optional().describe("Page number (default 1)"),
+      limit: z.number().int().positive().max(100).optional().describe("Items per page (default 20)"),
+    },
+    async (params) => {
+      const userId = getUserId();
+      const page = params.page ?? 1;
+      const limit = params.limit ?? 20;
+      const skip = (page - 1) * limit;
+
+      const filter = {
+        userId,
+        description: { $regex: params.query, $options: "i" },
+      };
+
+      const [transactions, total] = await Promise.all([
+        Transaction.find(filter).sort({ date: -1 }).skip(skip).limit(limit),
+        Transaction.countDocuments(filter),
+      ]);
+
+      return textResult({
+        data: transactions.map(formatTransaction),
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+        },
+      });
+    },
+  );
+
+  server.tool(
+    "create_transaction",
+    "Create a new transaction and adjust the account balance",
+    {
+      accountId: z.string().describe("Account ID"),
+      type: z.enum(["income", "expense", "transfer"]).describe("Transaction type"),
+      amount: z.number().positive().describe("Transaction amount"),
+      categoryId: z.string().describe("Category ID"),
+      description: z.string().max(200).describe("Transaction description"),
+      date: z.string().describe("Transaction date (ISO string)"),
+      subcategory: z.string().optional().describe("Subcategory"),
+      notes: z.string().optional().describe("Additional notes"),
+      isRecurring: z.boolean().optional().describe("Is this recurring?"),
+      tags: z.array(z.string()).optional().describe("Tags"),
+    },
+    async (params) => {
+      const userId = getUserId();
+      const account = await Account.findOne({
+        _id: params.accountId,
+        userId,
+      });
+      if (!account) throw McpToolError.notFound("Account not found");
+
+      const transaction = await Transaction.create({
+        userId,
+        accountId: params.accountId,
+        type: params.type,
+        amount: params.amount,
+        currency: account.currency,
+        categoryId: params.categoryId,
+        subcategory: params.subcategory,
+        description: params.description,
+        notes: params.notes,
+        date: new Date(params.date),
+        isRecurring: params.isRecurring ?? false,
+        tags: params.tags ?? [],
+      });
+
+      await adjustAccountBalance(
+        params.accountId,
+        params.type,
+        params.amount,
+        "add",
+      );
+
+      return textResult(formatTransaction(transaction));
+    },
+  );
+
+  server.tool(
+    "get_transaction",
+    "Get a transaction by ID, verifying ownership",
+    { transactionId: z.string().describe("The transaction ID") },
+    async ({ transactionId }) => {
+      const userId = getUserId();
+      const transaction = await Transaction.findOne({
+        _id: transactionId,
+        userId,
+      });
+      if (!transaction)
+        throw McpToolError.notFound("Transaction not found");
+      return textResult(formatTransaction(transaction));
+    },
+  );
+
+  server.tool(
+    "update_transaction",
+    "Update a transaction and adjust account balance for amount/type changes",
+    {
+      transactionId: z.string().describe("The transaction ID to update"),
+      accountId: z.string().optional().describe("New account ID"),
+      type: z.enum(["income", "expense", "transfer"]).optional().describe("New type"),
+      amount: z.number().positive().optional().describe("New amount"),
+      categoryId: z.string().optional().describe("New category ID"),
+      subcategory: z.string().nullable().optional().describe("New subcategory"),
+      description: z.string().max(200).optional().describe("New description"),
+      notes: z.string().nullable().optional().describe("New notes"),
+      date: z.string().optional().describe("New date (ISO string)"),
+      isRecurring: z.boolean().optional().describe("Is recurring"),
+      tags: z.array(z.string()).optional().describe("New tags"),
+    },
+    async ({ transactionId, ...data }) => {
+      const userId = getUserId();
+      const existing = await Transaction.findOne({
+        _id: transactionId,
+        userId,
+      });
+      if (!existing)
+        throw McpToolError.notFound("Transaction not found");
+
+      if (data.accountId && data.accountId !== existing.accountId.toString()) {
+        const newAccount = await Account.findOne({
+          _id: data.accountId,
+          userId,
+        });
+        if (!newAccount) throw McpToolError.notFound("Account not found");
+      }
+
+      await adjustAccountBalance(
+        existing.accountId.toString(),
+        existing.type,
+        existing.amount,
+        "remove",
+      );
+
+      const updateData: Record<string, unknown> = { ...data };
+      if (data.date) updateData.date = new Date(data.date);
+
+      const updated = await Transaction.findByIdAndUpdate(
+        transactionId,
+        { $set: updateData },
+        { new: true, runValidators: true },
+      );
+      if (!updated)
+        throw McpToolError.notFound("Transaction not found");
+
+      await adjustAccountBalance(
+        updated.accountId.toString(),
+        updated.type,
+        updated.amount,
+        "add",
+      );
+
+      return textResult(formatTransaction(updated));
+    },
+  );
+
+  server.tool(
+    "delete_transaction",
+    "Delete a transaction and reverse its effect on the account balance",
+    { transactionId: z.string().describe("The transaction ID to delete") },
+    async ({ transactionId }) => {
+      const userId = getUserId();
+      const transaction = await Transaction.findOneAndDelete({
+        _id: transactionId,
+        userId,
+      });
+      if (!transaction)
+        throw McpToolError.notFound("Transaction not found");
+
+      await adjustAccountBalance(
+        transaction.accountId.toString(),
+        transaction.type,
+        transaction.amount,
+        "remove",
+      );
+
+      return textResult(formatTransaction(transaction));
+    },
+  );
+}

--- a/mcp/src/transport/sse.ts
+++ b/mcp/src/transport/sse.ts
@@ -1,0 +1,65 @@
+import express from "express";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { resolveUserId } from "../auth/token-resolver";
+import { logger } from "../utils/logger";
+
+export function startSseTransport(
+  server: McpServer,
+  port: number,
+  setUserId: (id: string) => void,
+): void {
+  const app = express();
+
+  app.use((_req, res, next) => {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header(
+      "Access-Control-Allow-Headers",
+      "Origin, X-Requested-With, Content-Type, Accept, Authorization",
+    );
+    res.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    if (_req.method === "OPTIONS") {
+      res.sendStatus(204);
+      return;
+    }
+    next();
+  });
+
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", transport: "sse" });
+  });
+
+  let sseTransport: SSEServerTransport | null = null;
+
+  app.get("/sse", (req, res) => {
+    try {
+      const authHeader = req.headers.authorization;
+      const token = authHeader?.startsWith("Bearer ")
+        ? authHeader.slice(7)
+        : undefined;
+
+      const userId = resolveUserId("sse", token);
+      setUserId(userId);
+
+      sseTransport = new SSEServerTransport("/messages", res);
+      server.connect(sseTransport).catch((error) => {
+        logger.error({ error }, "Failed to connect SSE transport");
+      });
+    } catch (error) {
+      logger.error({ error }, "SSE connection error");
+      res.status(401).json({ error: "Unauthorized" });
+    }
+  });
+
+  app.post("/messages", (req, res) => {
+    if (!sseTransport) {
+      res.status(400).json({ error: "No active SSE connection" });
+      return;
+    }
+    sseTransport.handlePostMessage(req, res);
+  });
+
+  app.listen(port, () => {
+    logger.info(`MCP SSE server listening on port ${port}`);
+  });
+}

--- a/mcp/src/transport/stdio.ts
+++ b/mcp/src/transport/stdio.ts
@@ -1,0 +1,9 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { logger } from "../utils/logger";
+
+export async function startStdioTransport(server: McpServer): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  logger.info("MCP server started with stdio transport");
+}

--- a/mcp/src/utils/errors.ts
+++ b/mcp/src/utils/errors.ts
@@ -1,0 +1,27 @@
+import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+
+export class McpToolError extends Error {
+  public readonly code: number;
+
+  constructor(message: string, code: number = ErrorCode.InternalError) {
+    super(message);
+    this.name = "McpToolError";
+    this.code = code;
+  }
+
+  static notFound(message: string): McpToolError {
+    return new McpToolError(message, ErrorCode.InvalidParams);
+  }
+
+  static badRequest(message: string): McpToolError {
+    return new McpToolError(message, ErrorCode.InvalidParams);
+  }
+
+  static unauthorized(message: string): McpToolError {
+    return new McpToolError(message, ErrorCode.InvalidRequest);
+  }
+
+  static internal(message: string): McpToolError {
+    return new McpToolError(message, ErrorCode.InternalError);
+  }
+}

--- a/mcp/src/utils/logger.ts
+++ b/mcp/src/utils/logger.ts
@@ -1,0 +1,16 @@
+import pino from "pino";
+
+function getLogLevel(): string {
+  const env = process.env.NODE_ENV ?? "development";
+  if (env === "test") return "silent";
+  if (env === "production") return "info";
+  return "debug";
+}
+
+export const logger = pino({
+  level: getLogLevel(),
+  transport:
+    process.env.NODE_ENV === "development"
+      ? { target: "pino/file", options: { destination: 1 } }
+      : undefined,
+});

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/mcp/vitest.config.ts
+++ b/mcp/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    setupFiles: ["./src/__tests__/setup.ts"],
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,9 +11,42 @@ http {
         server api:4000;
     }
 
+    upstream mcp {
+        server mcp:5100;
+    }
+
+    upstream agentic_ai {
+        server agentic-ai:5200;
+    }
+
     server {
         listen 80;
         server_name localhost;
+
+        # MCP server (SSE — disable buffering)
+        location /mcp/ {
+            proxy_pass http://mcp/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 86400s;
+        }
+
+        # Agentic AI service (longer timeout for LLM calls)
+        location /agent/ {
+            proxy_pass http://agentic_ai/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 120s;
+            client_max_body_size 1M;
+        }
 
         # API requests
         location /api/ {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,17 @@
 {
   "name": "wealthwise",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wealthwise",
+      "version": "1.0.0",
       "workspaces": [
         "apps/*",
-        "packages/*"
+        "packages/*",
+        "mcp",
+        "agentic-ai"
       ],
       "devDependencies": {
         "prettier": "^3.8.1",
@@ -17,6 +21,26 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "agentic-ai": {
+      "name": "@wealthwise/agentic-ai",
+      "version": "1.0.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.39.0",
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "express": "^4.19.0",
+        "express-rate-limit": "^7.4.0",
+        "jsonwebtoken": "^9.0.2",
+        "pino": "^9.6.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.21",
+        "@types/jsonwebtoken": "^9.0.6",
+        "tsx": "^4.16.0",
+        "typescript": "^5.5.0",
+        "vitest": "^2.0.0"
       }
     },
     "apps/api": {
@@ -388,6 +412,26 @@
         }
       }
     },
+    "mcp": {
+      "name": "@wealthwise/mcp",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "express": "^4.19.0",
+        "jsonwebtoken": "^9.0.2",
+        "mongoose": "^8.5.0",
+        "pino": "^9.6.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.21",
+        "@types/jsonwebtoken": "^9.0.6",
+        "mongodb-memory-server": "^10.0.0",
+        "tsx": "^4.16.0",
+        "typescript": "^5.5.0",
+        "vitest": "^2.0.0"
+      }
+    },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
@@ -406,6 +450,36 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
+      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "9.1.2",
@@ -1023,12 +1097,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1040,12 +1114,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1057,12 +1131,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1074,12 +1148,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1091,12 +1165,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1108,12 +1182,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1125,12 +1199,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1142,12 +1216,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1159,12 +1233,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1176,12 +1250,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1193,12 +1267,12 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1210,12 +1284,12 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1227,12 +1301,12 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1244,12 +1318,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1261,12 +1335,12 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1278,12 +1352,12 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1295,12 +1369,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1312,12 +1386,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1329,12 +1403,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1346,12 +1420,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1363,12 +1437,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1380,12 +1454,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1397,12 +1471,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1414,12 +1488,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1431,12 +1505,12 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1448,12 +1522,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1495,6 +1569,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.10",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.10.tgz",
+      "integrity": "sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "3.10.0",
@@ -1556,6 +1642,373 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.6",
@@ -1759,6 +2212,12 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -3879,10 +4338,19 @@
       "version": "20.19.35",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
       "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/papaparse": {
@@ -4126,8 +4594,16 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@wealthwise/agentic-ai": {
+      "resolved": "agentic-ai",
+      "link": true
+    },
     "node_modules/@wealthwise/api": {
       "resolved": "apps/api",
+      "link": true
+    },
+    "node_modules/@wealthwise/mcp": {
+      "resolved": "mcp",
       "link": true
     },
     "node_modules/@wealthwise/shared-types": {
@@ -4137,6 +4613,18 @@
     "node_modules/@wealthwise/web": {
       "resolved": "apps/web",
       "link": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -4159,6 +4647,51 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -4269,6 +4802,21 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -4790,6 +5338,18 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
@@ -4891,6 +5451,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/css-tree": {
@@ -5182,6 +5756,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5366,6 +5949,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -5452,6 +6050,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -5466,6 +6073,27 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -5539,6 +6167,12 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-equals": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
@@ -5582,6 +6216,22 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -5673,6 +6323,41 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -5868,6 +6553,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -5878,6 +6578,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -5991,6 +6700,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6037,6 +6755,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -6112,11 +6839,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/jiti": {
       "version": "1.21.7",
@@ -6243,6 +6982,18 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7089,6 +7840,68 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -7148,6 +7961,15 @@
       "license": "MIT",
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -7288,6 +8110,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -7351,6 +8182,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -7358,6 +8226,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -7616,6 +8493,22 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7688,6 +8581,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/range-parser": {
@@ -7927,6 +8826,15 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/recharts": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
@@ -7977,7 +8885,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8068,6 +8975,55 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -8117,6 +9073,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8209,6 +9174,27 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -8294,6 +9280,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/sonner": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
@@ -8320,6 +9315,15 @@
       "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -8726,6 +9730,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -9058,7 +10071,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -9859,6 +10871,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -9916,6 +10937,21 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/why-is-node-running": {
@@ -10055,6 +11091,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "packages/shared-types": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "workspaces": [
     "apps/*",
-    "packages/*"
+    "packages/*",
+    "mcp",
+    "agentic-ai"
   ],
   "scripts": {
     "dev": "turbo dev",

--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -32,6 +32,26 @@ resource "aws_cloudwatch_log_group" "web" {
   }
 }
 
+resource "aws_cloudwatch_log_group" "mcp" {
+  name              = "/ecs/${var.project_name}-${var.environment}/mcp"
+  retention_in_days = 30
+
+  tags = {
+    Project     = "wealthwise"
+    Environment = var.environment
+  }
+}
+
+resource "aws_cloudwatch_log_group" "agentic_ai" {
+  name              = "/ecs/${var.project_name}-${var.environment}/agentic-ai"
+  retention_in_days = 30
+
+  tags = {
+    Project     = "wealthwise"
+    Environment = var.environment
+  }
+}
+
 resource "aws_ecs_task_definition" "api" {
   family                   = "${var.project_name}-${var.environment}-api"
   network_mode             = "awsvpc"
@@ -110,6 +130,84 @@ resource "aws_ecs_task_definition" "web" {
   }
 }
 
+resource "aws_ecs_task_definition" "mcp" {
+  family                   = "${var.project_name}-${var.environment}-mcp"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = var.execution_role_arn
+  task_role_arn            = var.task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "mcp"
+      image     = var.mcp_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = var.mcp_port
+          protocol      = "tcp"
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.mcp.name
+          "awslogs-region"        = data.aws_region.current.name
+          "awslogs-stream-prefix" = "mcp"
+        }
+      }
+    }
+  ])
+
+  tags = {
+    Project     = "wealthwise"
+    Environment = var.environment
+  }
+}
+
+resource "aws_ecs_task_definition" "agentic_ai" {
+  family                   = "${var.project_name}-${var.environment}-agentic-ai"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = var.execution_role_arn
+  task_role_arn            = var.task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "agentic-ai"
+      image     = var.agentic_ai_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = var.agentic_ai_port
+          protocol      = "tcp"
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.agentic_ai.name
+          "awslogs-region"        = data.aws_region.current.name
+          "awslogs-stream-prefix" = "agentic-ai"
+        }
+      }
+    }
+  ])
+
+  tags = {
+    Project     = "wealthwise"
+    Environment = var.environment
+  }
+}
+
 resource "aws_security_group" "ecs_tasks" {
   name_prefix = "${var.project_name}-${var.environment}-ecs-"
   description = "Security group for ECS tasks"
@@ -127,6 +225,22 @@ resource "aws_security_group" "ecs_tasks" {
     description     = "Allow traffic from ALB"
     from_port       = var.web_port
     to_port         = var.web_port
+    protocol        = "tcp"
+    security_groups = [var.alb_security_group_id]
+  }
+
+  ingress {
+    description     = "Allow traffic from ALB"
+    from_port       = var.mcp_port
+    to_port         = var.mcp_port
+    protocol        = "tcp"
+    security_groups = [var.alb_security_group_id]
+  }
+
+  ingress {
+    description     = "Allow traffic from ALB"
+    from_port       = var.agentic_ai_port
+    to_port         = var.agentic_ai_port
     protocol        = "tcp"
     security_groups = [var.alb_security_group_id]
   }
@@ -194,6 +308,54 @@ resource "aws_ecs_service" "web" {
   }
 }
 
+resource "aws_ecs_service" "mcp" {
+  name            = "${var.project_name}-${var.environment}-mcp"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.mcp.arn
+  desired_count   = var.min_capacity
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [aws_security_group.ecs_tasks.id]
+  }
+
+  load_balancer {
+    target_group_arn = var.mcp_target_group_arn
+    container_name   = "mcp"
+    container_port   = var.mcp_port
+  }
+
+  tags = {
+    Project     = "wealthwise"
+    Environment = var.environment
+  }
+}
+
+resource "aws_ecs_service" "agentic_ai" {
+  name            = "${var.project_name}-${var.environment}-agentic-ai"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.agentic_ai.arn
+  desired_count   = var.min_capacity
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [aws_security_group.ecs_tasks.id]
+  }
+
+  load_balancer {
+    target_group_arn = var.agentic_ai_target_group_arn
+    container_name   = "agentic-ai"
+    container_port   = var.agentic_ai_port
+  }
+
+  tags = {
+    Project     = "wealthwise"
+    Environment = var.environment
+  }
+}
+
 resource "aws_appautoscaling_target" "api" {
   max_capacity       = var.max_capacity
   min_capacity       = var.min_capacity
@@ -231,6 +393,52 @@ resource "aws_appautoscaling_policy" "web_cpu" {
   resource_id        = aws_appautoscaling_target.web.resource_id
   scalable_dimension = aws_appautoscaling_target.web.scalable_dimension
   service_namespace  = aws_appautoscaling_target.web.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value = 70.0
+  }
+}
+
+resource "aws_appautoscaling_target" "mcp" {
+  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.mcp.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "mcp_cpu" {
+  name               = "${var.project_name}-${var.environment}-mcp-cpu"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.mcp.resource_id
+  scalable_dimension = aws_appautoscaling_target.mcp.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.mcp.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value = 70.0
+  }
+}
+
+resource "aws_appautoscaling_target" "agentic_ai" {
+  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.agentic_ai.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "agentic_ai_cpu" {
+  name               = "${var.project_name}-${var.environment}-agentic-ai-cpu"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.agentic_ai.resource_id
+  scalable_dimension = aws_appautoscaling_target.agentic_ai.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.agentic_ai.service_namespace
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {

--- a/terraform/modules/compute/outputs.tf
+++ b/terraform/modules/compute/outputs.tf
@@ -18,6 +18,16 @@ output "web_service_name" {
   value       = aws_ecs_service.web.name
 }
 
+output "mcp_service_name" {
+  description = "Name of the MCP ECS service"
+  value       = aws_ecs_service.mcp.name
+}
+
+output "agentic_ai_service_name" {
+  description = "Name of the agentic AI ECS service"
+  value       = aws_ecs_service.agentic_ai.name
+}
+
 output "ecs_tasks_security_group_id" {
   description = "ID of the ECS tasks security group"
   value       = aws_security_group.ecs_tasks.id

--- a/terraform/modules/compute/variables.tf
+++ b/terraform/modules/compute/variables.tf
@@ -80,6 +80,38 @@ variable "web_target_group_arn" {
   type        = string
 }
 
+variable "mcp_image" {
+  description = "Docker image for the MCP service"
+  type        = string
+}
+
+variable "agentic_ai_image" {
+  description = "Docker image for the agentic AI service"
+  type        = string
+}
+
+variable "mcp_port" {
+  description = "Port the MCP container listens on"
+  type        = number
+  default     = 5100
+}
+
+variable "agentic_ai_port" {
+  description = "Port the agentic AI container listens on"
+  type        = number
+  default     = 5200
+}
+
+variable "mcp_target_group_arn" {
+  description = "ARN of the MCP ALB target group"
+  type        = string
+}
+
+variable "agentic_ai_target_group_arn" {
+  description = "ARN of the agentic AI ALB target group"
+  type        = string
+}
+
 variable "execution_role_arn" {
   description = "ARN of the ECS task execution IAM role"
   type        = string

--- a/terraform/modules/container-registry/variables.tf
+++ b/terraform/modules/container-registry/variables.tf
@@ -1,7 +1,7 @@
 variable "repository_names" {
   description = "List of ECR repository names to create"
   type        = list(string)
-  default     = ["wealthwise-api", "wealthwise-web"]
+  default     = ["wealthwise-api", "wealthwise-web", "wealthwise-mcp", "wealthwise-agentic-ai"]
 }
 
 variable "scan_on_push" {

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -28,7 +28,9 @@ resource "aws_cloudwatch_dashboard" "main" {
           title   = "ECS CPU Utilization"
           metrics = [
             ["AWS/ECS", "CPUUtilization", "ClusterName", var.cluster_name, "ServiceName", var.api_service_name],
-            ["AWS/ECS", "CPUUtilization", "ClusterName", var.cluster_name, "ServiceName", var.web_service_name]
+            ["AWS/ECS", "CPUUtilization", "ClusterName", var.cluster_name, "ServiceName", var.web_service_name],
+            ["AWS/ECS", "CPUUtilization", "ClusterName", var.cluster_name, "ServiceName", var.mcp_service_name],
+            ["AWS/ECS", "CPUUtilization", "ClusterName", var.cluster_name, "ServiceName", var.agentic_ai_service_name]
           ]
           period = 300
           stat   = "Average"
@@ -45,7 +47,9 @@ resource "aws_cloudwatch_dashboard" "main" {
           title   = "ECS Memory Utilization"
           metrics = [
             ["AWS/ECS", "MemoryUtilization", "ClusterName", var.cluster_name, "ServiceName", var.api_service_name],
-            ["AWS/ECS", "MemoryUtilization", "ClusterName", var.cluster_name, "ServiceName", var.web_service_name]
+            ["AWS/ECS", "MemoryUtilization", "ClusterName", var.cluster_name, "ServiceName", var.web_service_name],
+            ["AWS/ECS", "MemoryUtilization", "ClusterName", var.cluster_name, "ServiceName", var.mcp_service_name],
+            ["AWS/ECS", "MemoryUtilization", "ClusterName", var.cluster_name, "ServiceName", var.agentic_ai_service_name]
           ]
           period = 300
           stat   = "Average"
@@ -144,6 +148,102 @@ resource "aws_cloudwatch_metric_alarm" "web_high_cpu" {
   dimensions = {
     ClusterName = var.cluster_name
     ServiceName = var.web_service_name
+  }
+
+  tags = {
+    Project     = "wealthwise"
+    Environment = var.environment
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "mcp_high_cpu" {
+  alarm_name          = "${var.project_name}-${var.environment}-mcp-high-cpu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.cpu_threshold
+  alarm_description   = "MCP service CPU utilization is above ${var.cpu_threshold}%"
+  alarm_actions       = [aws_sns_topic.alarms.arn]
+  ok_actions          = [aws_sns_topic.alarms.arn]
+
+  dimensions = {
+    ClusterName = var.cluster_name
+    ServiceName = var.mcp_service_name
+  }
+
+  tags = {
+    Project     = "wealthwise"
+    Environment = var.environment
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "agentic_ai_high_cpu" {
+  alarm_name          = "${var.project_name}-${var.environment}-agentic-ai-high-cpu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.cpu_threshold
+  alarm_description   = "Agentic AI service CPU utilization is above ${var.cpu_threshold}%"
+  alarm_actions       = [aws_sns_topic.alarms.arn]
+  ok_actions          = [aws_sns_topic.alarms.arn]
+
+  dimensions = {
+    ClusterName = var.cluster_name
+    ServiceName = var.agentic_ai_service_name
+  }
+
+  tags = {
+    Project     = "wealthwise"
+    Environment = var.environment
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "mcp_unhealthy_hosts" {
+  alarm_name          = "${var.project_name}-${var.environment}-mcp-unhealthy-hosts"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "MCP target group has unhealthy hosts"
+  alarm_actions       = [aws_sns_topic.alarms.arn]
+  ok_actions          = [aws_sns_topic.alarms.arn]
+
+  dimensions = {
+    TargetGroup  = var.mcp_target_group_arn_suffix
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  tags = {
+    Project     = "wealthwise"
+    Environment = var.environment
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "agentic_ai_unhealthy_hosts" {
+  alarm_name          = "${var.project_name}-${var.environment}-agentic-ai-unhealthy-hosts"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "Agentic AI target group has unhealthy hosts"
+  alarm_actions       = [aws_sns_topic.alarms.arn]
+  ok_actions          = [aws_sns_topic.alarms.arn]
+
+  dimensions = {
+    TargetGroup  = var.agentic_ai_target_group_arn_suffix
+    LoadBalancer = var.alb_arn_suffix
   }
 
   tags = {

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -28,6 +28,26 @@ variable "web_target_group_arn_suffix" {
   type        = string
 }
 
+variable "mcp_service_name" {
+  description = "Name of the MCP ECS service"
+  type        = string
+}
+
+variable "agentic_ai_service_name" {
+  description = "Name of the agentic AI ECS service"
+  type        = string
+}
+
+variable "mcp_target_group_arn_suffix" {
+  description = "ARN suffix of the MCP target group"
+  type        = string
+}
+
+variable "agentic_ai_target_group_arn_suffix" {
+  description = "ARN suffix of the agentic AI target group"
+  type        = string
+}
+
 variable "alarm_email" {
   description = "Email address for alarm notifications"
   type        = string


### PR DESCRIPTION
This pull request introduces the initial setup for the `agentic-ai` package, including its build system, dependencies, and a comprehensive suite of agent-specific unit tests. The changes collectively enable development, testing, and deployment of multiple financial AI agents and their orchestration.

**Project setup and build system:**

* Added `agentic-ai/package.json` with scripts for development, build, testing, linting, and cleaning, along with all required dependencies and devDependencies for agentic AI functionality.
* Created a multi-stage `agentic-ai/Dockerfile` for building and deploying the package using Node.js, including workspace-aware dependency installation and production-ready output.

**Agent test suites:**

* Added full test suites for the following agents, each with mocked dependencies and multiple scenarios:
  - [`FinancialAdvisorAgent`](diffhunk://#diff-b715ad535329c4f2f6bc08ae3395be0f88e218a067c54300774df4a7a3ef9374R1-R167): tests for financial assessment, tool call execution, error handling, and history usage.
  - [`BudgetOptimizerAgent`](diffhunk://#diff-81dd5bfaf8c96c5131e813259e6d5c485d72fe9b30d70e1e373ab3fc8aac1b07R1-R83): tests for budget optimization, tool calls, and direct responses.
  - [`AnomalyDetectorAgent`](diffhunk://#diff-920e9cef88a149342f5014d6147974a743b9c4e95afaa7ff72dbaf7583ffa58cR1-R90): tests for anomaly analysis, tool usage, and no-anomaly cases.
  - [`ForecasterAgent`](diffhunk://#diff-1add21f6e981c3417c57eced3693ff39f2897a8163f7ea4713c44709ec3a5eddR1-R106): tests for financial projections, parallel tool calls, and usage tracking.
  - [`OrchestratorAgent`](diffhunk://#diff-108dbe3d873594bf91a9625b0b2c5c1aa64f25e4aba08ae11f139cbc84d04c54R1-R102): tests for agent routing logic and agent retrieval by name.

**Local development configuration:**

* Updated `.claude/settings.local.json` to add support for new agentic AI commands and plugins, including memory and git analysis tools, and enhanced TypeScript build options.