### PR TITLE
feat(docs): add comprehensive instructions for Codex, Copilot, and Claude Code

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,296 @@
+# `.agents/skills` README
+
+This directory contains the Codex skill system for WealthWise. Skills are reusable workflow instructions that teach Codex how to handle recurring repository tasks such as scaffolding endpoints, creating pages, seeding data, running health checks, or validating a branch before a PR.
+
+These skills are referenced by the root [`AGENTS.md`](../../AGENTS.md), which advertises them to Codex and defines when they should be loaded explicitly or implicitly.
+
+## Directory structure
+
+```text
+.agents/skills/
+├── api-endpoint/
+│   ├── agents/
+│   │   └── openai.yaml
+│   └── SKILL.md
+├── db-seed/
+│   ├── agents/
+│   │   └── openai.yaml
+│   └── SKILL.md
+├── docker-up/
+│   ├── agents/
+│   │   └── openai.yaml
+│   └── SKILL.md
+├── health-check/
+│   └── SKILL.md
+├── new-model/
+│   └── SKILL.md
+├── new-page/
+│   ├── agents/
+│   │   └── openai.yaml
+│   └── SKILL.md
+├── pre-pr/
+│   ├── agents/
+│   │   └── openai.yaml
+│   └── SKILL.md
+└── test-coverage/
+    └── SKILL.md
+```
+
+## How the skill system works
+
+Each skill lives in its own folder and usually contains:
+
+- `SKILL.md`
+  - The main instruction file
+  - Includes the skill name, description, scope, workflow, safety rules, and verification steps
+- `agents/openai.yaml` (optional)
+  - Tooling or agent metadata used by the local skill system when available
+  - Not every skill needs one
+
+## How skills are activated
+
+Based on the repo-level rules in [`AGENTS.md`](../../AGENTS.md), skills can activate in two ways:
+
+### Explicit invocation
+
+The user names the skill directly, for example:
+- `$api-endpoint budget-note`
+- `$new-page net-worth`
+- `$docker-up logs`
+
+When that happens, Codex must load and follow the skill.
+
+### Implicit activation
+
+If the request clearly matches the skill description, Codex should load the skill automatically.
+
+Examples:
+- "Add an endpoint for recurring bills" -> `api-endpoint`
+- "Create a dashboard page for investment holdings" -> `new-page`
+- "Run the pre-PR checks" -> `pre-pr`
+
+## Current skills
+
+### `api-endpoint`
+
+Path: [`api-endpoint/SKILL.md`](./api-endpoint/SKILL.md)
+
+Purpose:
+- Scaffold a full backend endpoint across shared-types and API layers
+
+Creates or updates:
+- Zod schema
+- inferred types
+- Mongoose model
+- service
+- controller
+- route
+- route registration
+
+Key rules:
+- Every query filters by `userId`
+- Use `ApiError` factories
+- Named exports only
+- Verify with `npx turbo lint --filter=@wealthwise/api` and `npx turbo test --filter=@wealthwise/api`
+
+### `db-seed`
+
+Path: [`db-seed/SKILL.md`](./db-seed/SKILL.md)
+
+Purpose:
+- Seed the API database with system categories or full demo data
+
+Modes:
+- default or `categories`
+- `demo`
+- `all`
+
+Key rules:
+- Confirm `.env` exists without reading it
+- Warn if production-like context is detected
+- Report what the seed created
+
+### `docker-up`
+
+Path: [`docker-up/SKILL.md`](./docker-up/SKILL.md)
+
+Purpose:
+- Manage the Docker Compose development or production environment
+
+Modes:
+- `dev`
+- `prod`
+- `down`
+- `down --volumes`
+- `logs`
+
+Key rules:
+- Check Docker daemon and port conflicts
+- Treat `down --volumes` as destructive
+- Report container health after start
+
+### `health-check`
+
+Path: [`health-check/SKILL.md`](./health-check/SKILL.md)
+
+Purpose:
+- Verify local API, web, Docker, and MongoDB health
+
+Checks:
+- API endpoint
+- web status code
+- Docker container status
+- MongoDB connectivity inferred through API health
+
+Key rules:
+- Report failures cleanly
+- Suggest follow-up commands if services are down
+
+### `new-model`
+
+Path: [`new-model/SKILL.md`](./new-model/SKILL.md)
+
+Purpose:
+- Scaffold a Mongoose model and CRUD service without adding routes or frontend work
+
+Creates:
+- model
+- service
+
+Key rules:
+- Always include `userId`
+- Use `ApiError`
+- Never return cross-user data
+- Keep the scope to the data layer only
+
+### `new-page`
+
+Path: [`new-page/SKILL.md`](./new-page/SKILL.md)
+
+Purpose:
+- Scaffold a new dashboard page in `apps/web/`
+
+Creates or updates:
+- TanStack Query hooks
+- feature components
+- dashboard page
+- sidebar link
+
+Key rules:
+- Use `apiClient`
+- Use TanStack Query, not raw `fetch`
+- Use React Hook Form + `zodResolver`
+- Add loading, error, and empty states
+- Verify with web lint and tests
+
+### `pre-pr`
+
+Path: [`pre-pr/SKILL.md`](./pre-pr/SKILL.md)
+
+Purpose:
+- Run the repo's standard validation flow before a pull request
+
+Checks:
+- formatting
+- type-checking
+- tests
+- build
+- dependency audit
+- branch safety
+
+Key rules:
+- Stop on first failure unless `--all` is requested
+- Report pass/fail for each gate
+- Flag secrets or `.env` changes immediately
+
+### `test-coverage`
+
+Path: [`test-coverage/SKILL.md`](./test-coverage/SKILL.md)
+
+Purpose:
+- Run coverage for all packages or a selected package
+
+Scopes:
+- all
+- `api`
+- `web`
+- `types` / `shared-types`
+
+Key rules:
+- Report total pass/fail counts
+- Report coverage percentages
+- Highlight files with low branch coverage
+- Do not auto-fix failures unless asked
+
+## Skill authoring guidelines
+
+When adding or editing a skill, follow these rules:
+
+### Keep the scope narrow
+
+A skill should solve one repeatable workflow, not describe the whole repository.
+
+Good examples:
+- scaffold an endpoint
+- run health checks
+- seed demo data
+
+Bad examples:
+- "do backend work"
+- "fix the app"
+
+### Use real repository commands
+
+Skills should reference commands that actually exist in this repository, such as:
+- `npm run dev`
+- `npm run lint`
+- `npx turbo test --filter=@wealthwise/api`
+
+If package names or scripts change, update the affected skills immediately.
+
+### Encode safety checks
+
+Good skills explicitly say:
+- when to confirm destructive actions
+- when not to read `.env`
+- how to verify the result
+- when not to keep going automatically
+
+### Prefer deterministic steps
+
+A strong skill tells Codex:
+- what to inspect
+- what to create or update
+- what constraints apply
+- what success looks like
+
+## Keeping skills aligned with the rest of the repo
+
+When a skill changes, check these files too:
+
+- [`AGENTS.md`](../../AGENTS.md)
+  - Update the available-skills table if the skill list or description changes
+- [`.claude/skills`](../../.claude/skills)
+  - Keep Claude slash-command versions aligned with shared workflows
+- [`.codex/README.md`](../../.codex/README.md) and [`.claude/README.md`](../../.claude/README.md)
+  - Update higher-level documentation if the toolkit changes materially
+
+## Adding a new skill
+
+1. Create a folder: `.agents/skills/<skill-name>/`
+2. Add `SKILL.md` with:
+   - frontmatter name and description
+   - scope
+   - step-by-step workflow
+   - safety rules
+   - verification expectations
+3. Add `agents/openai.yaml` only if the local skill tooling needs it.
+4. Register the skill in [`AGENTS.md`](../../AGENTS.md).
+5. If Claude should support the same workflow, add `.claude/skills/<skill-name>.md`.
+
+## Recommended maintenance practice
+
+- Review skills whenever scripts, package names, or folder structure change.
+- Keep examples concrete and current.
+- Prefer simple operational guidance over long theoretical explanation.
+- Treat skill definitions as executable documentation: if they drift from reality, the automation quality drops quickly.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,215 @@
+# `.claude` README
+
+This directory contains repository-specific Claude Code configuration for WealthWise. It supplements the root [`CLAUDE.md`](../CLAUDE.md), which defines project conventions for architecture, coding standards, testing, and package structure.
+
+Use this directory when you want to understand how Claude Code is customized for this repository: which slash-command skills exist, which specialist agents are available, what hooks run automatically, and which tools/commands are pre-approved.
+
+## What lives here
+
+```text
+.claude/
+├── agents/
+│   ├── api-developer.md
+│   ├── schema-author.md
+│   └── web-developer.md
+├── skills/
+│   ├── api-endpoint.md
+│   ├── db-seed.md
+│   ├── docker-up.md
+│   ├── health-check.md
+│   ├── new-model.md
+│   ├── new-page.md
+│   ├── pre-pr.md
+│   └── test-coverage.md
+├── settings.json
+└── settings.local.json
+```
+
+## How Claude Code uses this directory
+
+1. Claude Code loads the root [`CLAUDE.md`](../CLAUDE.md) for repo-wide behavior.
+2. Claude Code reads [`.claude/settings.json`](./settings.json) for hooks.
+3. Claude Code reads [`.claude/settings.local.json`](./settings.local.json) for the current permission allowlist.
+4. Slash commands are defined in [`./skills`](./skills).
+5. Specialist sub-agents are defined in [`./agents`](./agents).
+
+## `settings.json`
+
+File: [`settings.json`](./settings.json)
+
+This file defines two automation hooks:
+
+### `PostToolUse`
+
+Matcher:
+- `Write|Edit`
+
+Behavior:
+- If Claude writes or edits a file ending in `.ts`, `.tsx`, `.js`, `.jsx`, `.json`, `.css`, or `.md`, a shell hook runs `npx prettier --write` on that file.
+
+Why it exists:
+- Keeps generated or edited files formatted automatically
+- Reduces review noise from inconsistent formatting
+- Aligns Claude edits with the repository's Prettier configuration
+
+### `PreToolUse`
+
+Matcher:
+- `Bash`
+
+Behavior:
+- Before a shell command runs, a shell hook scans the command text.
+- If it detects destructive git patterns such as `--force`, `reset --hard`, `clean -f`, `branch -D`, or `checkout --`, it prints a warning.
+
+Why it exists:
+- Adds a lightweight safety rail before risky git commands
+- Encourages an explicit review moment without blocking normal development
+
+## `settings.local.json`
+
+File: [`settings.local.json`](./settings.local.json)
+
+This file defines the current Claude Code permission allowlist for this repository.
+
+The committed allowlist currently includes:
+- Common development shell commands such as `npm run`, `npx turbo`, `npx tsc`, and `npx vitest`
+- Docker and Helm commands used in this project
+- A few MCP tool permissions
+- Larger-memory `tsc` invocations using `NODE_OPTIONS`
+
+Treat this file carefully:
+- Keep permissions as narrow as possible
+- Prefer allowing stable command prefixes instead of single huge wildcards
+- Review new entries before committing them
+- Do not add secrets, personal paths, or machine-only assumptions
+
+## Claude agents
+
+The files in [`./agents`](./agents) define specialist sub-agents for Claude Code.
+
+### `api-developer`
+
+File: [`agents/api-developer.md`](./agents/api-developer.md)
+
+Scope:
+- `apps/api/`
+
+Use for:
+- Endpoints
+- Controllers
+- Services
+- Models
+- Middleware
+- Backend code review
+
+Key enforced behavior:
+- Every query must filter by `userId`
+- Use `ApiError` factories, never raw `Error`
+- Wrap async handlers with `asyncHandler`
+- Keep route/controller/service/model boundaries clean
+
+### `web-developer`
+
+File: [`agents/web-developer.md`](./agents/web-developer.md)
+
+Scope:
+- `apps/web/`
+
+Use for:
+- Dashboard pages
+- Components
+- Hooks
+- Forms
+- Frontend bugs
+
+Key enforced behavior:
+- TanStack Query for remote state
+- React Hook Form + `zodResolver` for forms
+- Sonner toasts on all mutations
+- Explicit loading, error, and empty states
+- Tailwind + shadcn/ui conventions
+
+### `schema-author`
+
+File: [`agents/schema-author.md`](./agents/schema-author.md)
+
+Scope:
+- `packages/shared-types/`
+
+Use for:
+- Zod schemas
+- Inferred types
+- Shared-type barrel exports
+
+Key enforced behavior:
+- Types must be inferred with `z.infer`
+- Each entity should expose create, update, response, and list schemas
+- Consumer packages should continue to compile after schema changes
+
+## Claude skills
+
+The files in [`./skills`](./skills) define project-specific slash commands for Claude Code.
+
+Current skills:
+
+| Skill | Main purpose | Typical command |
+|-------|--------------|-----------------|
+| `api-endpoint` | Scaffold a backend endpoint end-to-end | `/api-endpoint budget-note` |
+| `db-seed` | Seed categories or demo data | `/db-seed demo` |
+| `docker-up` | Start, stop, or inspect Docker environments | `/docker-up logs api` |
+| `health-check` | Check local API, web, and MongoDB health | `/health-check` |
+| `new-model` | Create a Mongoose model and CRUD service | `/new-model recurring-payment` |
+| `new-page` | Scaffold a dashboard page and related hooks/components | `/new-page net-worth` |
+| `pre-pr` | Run repo validation checks before opening a PR | `/pre-pr` |
+| `test-coverage` | Run coverage for all or selected packages | `/test-coverage api` |
+
+Each skill file should:
+- State the trigger or scope clearly
+- Describe the exact commands or files involved
+- Encode project conventions directly in the workflow
+- Include post-run reporting expectations
+
+## Relationship to `.agents/skills`
+
+This repository also contains [`.agents/skills`](../.agents/skills), which defines the skill system used by Codex. The Claude skill files and the Codex skill files cover the same high-level workflows, but they use different formats and execution models.
+
+Keep them aligned:
+- If you add or rename a skill in `.claude/skills`, update `.agents/skills` too when the workflow should exist for both tools.
+- If you change the recommended commands, update both copies.
+- If the skill represents a shared repo workflow, document it in the root instruction file as well.
+
+## Maintenance guidelines
+
+When editing `.claude`, keep the following in mind:
+
+- Update [`CLAUDE.md`](../CLAUDE.md) when the project-wide convention changes.
+- Update [`settings.json`](./settings.json) only for reusable automation that should run on most Claude sessions.
+- Update [`settings.local.json`](./settings.local.json) only when command approvals genuinely need to change.
+- Keep agent prompts package-focused. Avoid mixing API and frontend instructions into the same specialist.
+- Keep skills operational and concrete. A skill should tell Claude exactly what good execution looks like.
+
+## Adding a new Claude skill
+
+1. Add `skills/<name>.md`.
+2. Describe the task scope, required steps, safety checks, and verification.
+3. Use actual package names and repo commands.
+4. If the workflow also matters for Codex, add the matching `.agents/skills/<name>/SKILL.md`.
+5. Document the new skill in [`CLAUDE.md`](../CLAUDE.md) if it becomes part of the standard toolkit.
+
+## Adding a new Claude agent
+
+1. Add `agents/<name>.md`.
+2. Define:
+   - scope
+   - environment
+   - non-negotiable rules
+   - testing expectations
+3. Keep the instructions specific to one part of the monorepo.
+4. Reuse repository conventions from [`CLAUDE.md`](../CLAUDE.md) instead of duplicating every detail.
+
+## Recommended workflow
+
+- Start with the root [`CLAUDE.md`](../CLAUDE.md) for overall project conventions.
+- Use a specialist agent when the task is clearly package-specific.
+- Use a slash-command skill when the repository already has a standard workflow for that task.
+- Treat `.claude` changes as operational infrastructure. Small edits here can materially change how Claude behaves across the entire repository.

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,232 @@
+# `.codex` README
+
+This directory contains the repository-specific Codex configuration for WealthWise. It complements the root [`AGENTS.md`](../AGENTS.md), which defines project conventions, architecture, testing expectations, and skill discovery rules.
+
+Use this directory when you want to understand or change how Codex behaves inside this repository: which specialist roles exist, how multi-agent work is configured, and which shell commands run freely versus requiring confirmation.
+
+## What lives here
+
+```text
+.codex/
+├── agents/
+│   ├── api-developer.toml
+│   ├── explorer.toml
+│   ├── schema-author.toml
+│   ├── web-developer.toml
+│   └── worker.toml
+├── config.toml
+└── rules/
+    └── default.rules
+```
+
+## How Codex uses this directory
+
+1. Codex loads the repo-level [`AGENTS.md`](../AGENTS.md) for shared project instructions.
+2. Codex reads [`.codex/config.toml`](./config.toml) to discover role definitions, thread limits, and role-specific configuration files.
+3. Codex reads [`.codex/rules/default.rules`](./rules/default.rules) to determine whether commands are automatically allowed, require a prompt, or are blocked.
+4. When a role is spawned, Codex loads the corresponding file in [`./agents`](./agents) and applies the role-specific developer instructions in addition to the repo-wide rules.
+
+Personal overrides should live in `~/.codex/config.toml`, not in this repository.
+
+## `config.toml`
+
+[`.codex/config.toml`](./config.toml) is the entry point for Codex multi-agent behavior in this repository.
+
+It currently defines:
+
+- Global agent concurrency limits:
+  - `max_threads = 8`
+  - `max_depth = 2`
+  - `job_max_runtime_seconds = 1800`
+- Two general-purpose built-in roles:
+  - `explorer`
+  - `worker`
+- Three WealthWise-specific specialist roles:
+  - `api-developer`
+  - `web-developer`
+  - `schema-author`
+
+These descriptions are not just documentation. They shape how Codex chooses or delegates to sub-agents during implementation work.
+
+## Role catalog
+
+### `explorer`
+
+File: [`agents/explorer.toml`](./agents/explorer.toml)
+
+Purpose:
+- Fast, read-only codebase mapping
+- Tracing execution paths
+- Identifying affected files, tests, and gotchas before proposing changes
+
+Important constraints:
+- Uses `sandbox_mode = "read-only"`
+- Should not edit files or perform mutating operations
+
+Use it when:
+- You need a quick map of an unfamiliar feature
+- You want to identify the real call chain before changing code
+- You want supporting evidence for a review or refactor plan
+
+### `worker`
+
+File: [`agents/worker.toml`](./agents/worker.toml)
+
+Purpose:
+- Focused implementation for targeted fixes and small features
+- Minimal, local changes with verification
+
+Important constraints:
+- Keep unrelated files untouched
+- Never touch `.env` files
+- Never use `any`
+- Never throw raw `Error` in the API layer
+
+Use it when:
+- The change is already understood
+- You want a bounded implementation agent rather than a deep specialist
+
+### `api-developer`
+
+File: [`agents/api-developer.toml`](./agents/api-developer.toml)
+
+Purpose:
+- Specialist for `apps/api/`
+- Enforces WealthWise API conventions and layer separation
+
+Key knowledge baked into the role:
+- `routes` contain routing and Swagger docs only
+- `controllers` call one service method and do not contain business logic
+- `services` own all business logic and must always filter by `userId`
+- `models` own all indexes
+- `ApiError` factories and `asyncHandler` are mandatory
+
+Use it when:
+- Adding or fixing REST endpoints
+- Editing services, models, middleware, or controllers
+- Reviewing backend safety and user isolation
+
+### `web-developer`
+
+File: [`agents/web-developer.toml`](./agents/web-developer.toml)
+
+Purpose:
+- Specialist for `apps/web/`
+- Enforces Next.js, TanStack Query, form, and UI conventions
+
+Key knowledge baked into the role:
+- Use `lib/api-client.ts`, not raw `fetch`
+- All remote state goes through TanStack Query
+- All forms use React Hook Form + `zodResolver`
+- Mutations require Sonner success and error toasts
+- Components must handle loading, error, and empty states
+- Tailwind + shadcn/ui conventions are mandatory
+
+Use it when:
+- Building pages, hooks, or dashboard components
+- Fixing frontend bugs
+- Reviewing UI data flows or mutation behavior
+
+### `schema-author`
+
+File: [`agents/schema-author.toml`](./agents/schema-author.toml)
+
+Purpose:
+- Specialist for `packages/shared-types/`
+- Keeps Zod schemas and inferred types consistent across consumers
+
+Key knowledge baked into the role:
+- Every entity schema should export create, update, response, and list schemas
+- `types/index.ts` should use `z.infer`
+- API and web consumers must continue to compile after schema changes
+
+Use it when:
+- Adding a new schema file
+- Changing validation rules
+- Updating inferred types and barrel exports
+
+## Command rules
+
+[`.codex/rules/default.rules`](./rules/default.rules) uses Codex prefix rules to control shell access.
+
+The current rule set is organized around three outcomes:
+
+### Allowed by default
+
+Examples:
+- `npm run ...`
+- `npx turbo ...`
+- `npx tsc ...`
+- `npx prettier ...`
+- `npm ci`
+- `docker compose ps`
+- `docker compose logs`
+- `curl -sf ...` for localhost health checks
+- Read-only git commands such as `git status`, `git diff`, `git log`, and `git show`
+- `git add`
+- `npm audit`
+
+These are treated as normal development operations.
+
+### Prompt before running
+
+Examples:
+- `npm install ...`
+- `docker compose up/down/restart/build`
+- `git commit`
+- `git checkout`
+- `git merge`
+- `git rebase`
+- `git push`
+- `git reset`
+- `git clean`
+- `rm -rf ...`
+
+These operations are useful, but they modify state, affect shared environments, or can discard work.
+
+### Forbidden or heavily guarded
+
+Examples:
+- Direct push to `main` or `master`
+- Force push with `--force` or `-f`
+
+These are blocked because they create unnecessary risk in a collaborative repository.
+
+## Maintenance guidelines
+
+When changing Codex behavior, keep these files aligned:
+
+- Update [`AGENTS.md`](../AGENTS.md) if you change project-level conventions or add/remove skills.
+- Update [`.codex/config.toml`](./config.toml) if you add a new Codex role.
+- Add a matching file in [`./agents`](./agents) for every new role declared in `config.toml`.
+- Update [`.codex/rules/default.rules`](./rules/default.rules) only when the command safety policy truly changes.
+
+Practical rules for edits:
+- Keep role instructions narrowly scoped to the package or workflow they own.
+- Prefer reusable conventions over task-specific wording.
+- Review appended rules before committing them; interactive sessions may add new entries.
+- Do not encode secrets, tokens, or machine-specific paths here.
+
+## Extending this directory
+
+### Add a new role
+
+1. Create `agents/<role-name>.toml`.
+2. Define the model, reasoning effort, and developer instructions.
+3. Register the role in [`config.toml`](./config.toml) with a description and `config_file`.
+4. If the role maps to a major repo surface area, document it in [`AGENTS.md`](../AGENTS.md).
+
+### Change command approval behavior
+
+1. Edit [`rules/default.rules`](./rules/default.rules).
+2. Prefer narrowly scoped prefixes over broad allow rules.
+3. Use `prompt` for actions that change shared state or can delete work.
+4. Avoid adding rules that would allow destructive commands silently.
+
+## Recommended workflow
+
+- Read the root [`AGENTS.md`](../AGENTS.md) first for repo-wide conventions.
+- Use `explorer` for discovery when the affected files are not obvious.
+- Use a specialist role for package-specific work whenever the change is substantial.
+- Use `worker` for small, well-understood fixes.
+- Treat `.codex` as behavioral infrastructure: changes here affect every future Codex session in this repository.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,45 @@
+# WealthWise Copilot Instructions
+
+- This repository is a Turborepo monorepo for a personal finance product. Main packages are `apps/api`, `apps/web`, `packages/shared-types`, `mcp`, and `agentic-ai`.
+- Prefer the smallest defensible change that matches existing local patterns. Read nearby files before introducing new structure, abstractions, or dependencies.
+- Keep unrelated files untouched. Do not opportunistically refactor while solving a scoped task.
+- Use the exact Turbo package names when filtering tasks: `@wealthwise/api`, `@wealthwise/web`, `@wealthwise/shared-types`, `@wealthwise/mcp`, and `@wealthwise/agentic-ai`.
+
+## API rules
+
+- `apps/api` uses Express 4, TypeScript, Mongoose, and Zod schemas from `@wealthwise/shared-types`.
+- Every database query must filter by `userId`. There is no cross-user access pattern.
+- Keep layer boundaries strict:
+  - `routes/`: routing and Swagger JSDoc only
+  - `controllers/`: parse request, call one service method, return response
+  - `services/`: all business logic and DB access
+  - `models/`: schema and indexes
+- Use `ApiError.badRequest`, `unauthorized`, `forbidden`, `notFound`, and `internal`. Never `throw new Error(...)` in the API layer.
+- Wrap async handlers with `asyncHandler`.
+- Return API responses as `{ success: true, data }` or `{ success: false, error: { code, message, details? } }`.
+
+## Web rules
+
+- `apps/web` uses Next.js 14 App Router, React 18, Tailwind CSS, shadcn/ui, TanStack Query v5, React Hook Form, and Sonner.
+- Use TanStack Query for all remote data fetching. Do not introduce raw `fetch` inside React components.
+- Use `apps/web/src/lib/api-client.ts` for API calls. Do not manually attach auth tokens.
+- Use React Hook Form + `zodResolver` with schemas from `@wealthwise/shared-types`.
+- Show Sonner success and error toasts for every mutation.
+- Handle loading, error, and empty states explicitly on data-driven screens.
+- Use Tailwind CSS only. Prefer existing shadcn/ui primitives in `components/ui/` before building custom UI.
+- HSL design tokens use the format `220 13% 91%`, not `hsl(220, 13%, 91%)`.
+- Do not add files under `app/api/` except the existing NextAuth catch-all route.
+
+## Shared types rules
+
+- `packages/shared-types` is the source of truth for request and response validation.
+- Prefer Zod schemas over handwritten runtime validation.
+- Each entity schema should export `Create<Entity>Schema`, `Update<Entity>Schema`, `<Entity>ResponseSchema`, and `<Entity>ListResponseSchema`.
+- Infer TypeScript types with `z.infer`; do not hand-write types that can be inferred from schemas.
+
+## Testing and safety
+
+- Run lint and tests for the package you changed before considering the work done.
+- API and MCP tests use `mongodb-memory-server`; do not reduce the 30-second startup timeout.
+- Web Vitest config must not add `@vitejs/plugin-react`.
+- Never modify `.env` files, log secrets, or commit credentials.


### PR DESCRIPTION
This pull request introduces comprehensive documentation for the repository's automation and agent infrastructure, clarifying how Codex, Claude, and Copilot are configured and used within WealthWise. The new README files detail skill systems, agent roles, command safety, and project conventions, making it easier for developers and automation tools to follow consistent workflows and safety rules.

**Codex and Claude agent/skill system documentation:**

* Added `.agents/skills/README.md` to describe the Codex skill system, including skill structure, activation methods, authoring guidelines, and maintenance practices. This file documents all current skills, their purposes, rules, and how they integrate with the rest of the repository.
* Added `.codex/README.md` to document Codex-specific configuration, role catalog, command approval rules, and maintenance guidelines. This file explains how Codex agents are defined, how command safety is enforced, and how to extend or modify Codex behavior.
* Added `.claude/README.md` to describe Claude Code configuration, including agent and skill structure, automation hooks, permission allowlist, and maintenance workflow. This file clarifies how Claude agents and skills are aligned with Codex and how to safely add or modify Claude-specific workflows.

**Copilot instructions:**

* Added `.github/copilot-instructions.md` to provide explicit, package-scoped rules and conventions for Copilot, covering API, web, shared types, and testing/safety. This file ensures Copilot-generated changes follow strict local patterns and avoid risky or unrelated edits.