### PR TITLE
feat(infra): add Coralogix observability across all deployment layers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,7 @@ MCP_TRANSPORT=sse
 AGENT_PORT=5200
 MCP_SERVER_URL=http://localhost:5100
 ANTHROPIC_API_KEY=
+
+# ── Coralogix Observability ──────────────────────────────────────────────────
+# CX_API_KEY=your-coralogix-send-your-data-api-key
+# CX_DOMAIN=coralogix.us

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,7 +29,8 @@
 [![Helm](https://img.shields.io/badge/Helm-0F1689?logo=helm&logoColor=white)](https://helm.sh/)
 [![Kustomize](https://img.shields.io/badge/Kustomize-326CE5?logo=kubernetes&logoColor=white)](https://kustomize.io/)
 [![Terraform](https://img.shields.io/badge/Terraform-7B42BC?logo=terraform&logoColor=white)](https://www.terraform.io/)
-[![AWS](https://img.shields.io/badge/AWS-232F3E?logo=amazonaws&logoColor=white)](https://aws.amazon.com/)
+[![Coralogix](https://img.shields.io/badge/Coralogix-DB2828?logo=datadog&logoColor=white)](https://coralogix.com/)
+[![AWS](https://img.shields.io/badge/Amazon_Web_Services-232F3E?logo=task&logoColor=white)](https://aws.amazon.com/)
 [![ECS Fargate](https://img.shields.io/badge/ECS_Fargate-FF9900?logo=amazonaws&logoColor=white)](https://aws.amazon.com/fargate/)
 [![CloudFormation](https://img.shields.io/badge/CloudFormation-FF4F8B?logo=amazonaws&logoColor=white)](https://aws.amazon.com/cloudformation/)
 [![DocumentDB](https://img.shields.io/badge/DocumentDB-C925D1?logo=amazonaws&logoColor=white)](https://aws.amazon.com/documentdb/)
@@ -51,7 +52,7 @@
 [![Anthropic Claude](https://img.shields.io/badge/Claude-Anthropic-cc785c?logo=anthropic&logoColor=white)](https://anthropic.com/)
 [![Google Gemini](https://img.shields.io/badge/Gemini-Google-4285f4?logo=google&logoColor=white)](https://ai.google.dev/gemini)
 [![Pino](https://img.shields.io/badge/Pino-9-687634)](https://getpino.io/)
-[![esbuild](https://img.shields.io/badge/esbuild-0.27-ffcf00?logo=esbuild&logoColor=black)](https://esbuild.github.io/)
+[![esbuild](https://img.shields.io/badge/esbuild-0.27-ffcf00?logo=esbuild&logoColor=white)](https://esbuild.github.io/)
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,6 +87,10 @@
   - [Production (Docker/Podman Compose)](#production-dockerpodman-compose)
   - [Nginx Routing](#nginx-routing)
   - [Development vs Production](#development-vs-production)
+- [Observability Architecture](#observability-architecture)
+  - [Coralogix Pipeline (Kubernetes)](#coralogix-pipeline-kubernetes)
+  - [Coralogix Pipeline (Docker Compose)](#coralogix-pipeline-docker-compose)
+  - [Terraform-Managed Coralogix Resources](#terraform-managed-coralogix-resources)
 - [Shared Types Contract](#shared-types-contract)
   - [Schema Coverage](#schema-coverage)
 - [Testing Strategy](#testing-strategy)
@@ -1015,6 +1019,14 @@ graph TD
     MCP --> DB
     AI -- "MCP protocol" --> MCP
 
+    API -. "fluentd driver" .-> FB["Fluent Bit<br/><i>log shipper</i>"]
+    WEB -. "fluentd driver" .-> FB
+    MCP -. "fluentd driver" .-> FB
+    AI -. "fluentd driver" .-> FB
+    NGINX -. "fluentd driver" .-> FB
+    FB -- "HTTP/TLS" --> CX["Coralogix"]
+    OTEL["OTEL Collector<br/><i>metrics + traces</i>"] -- "OTEL export" --> CX
+
     subgraph NETWORK["wealthwise-network (bridge)"]
         NGINX
         API
@@ -1022,6 +1034,8 @@ graph TD
         MCP
         AI
         DB
+        FB
+        OTEL
     end
 
     style CLIENT fill:#6366f1,stroke:#000,color:#fff
@@ -1031,6 +1045,9 @@ graph TD
     style MCP fill:#4f46e5,stroke:#000,color:#fff
     style AI fill:#cc785c,stroke:#000,color:#fff
     style DB fill:#47a248,stroke:#000,color:#fff
+    style FB fill:#e11d48,stroke:#000,color:#fff
+    style OTEL fill:#e11d48,stroke:#000,color:#fff
+    style CX fill:#e11d48,stroke:#000,color:#fff
     style NETWORK fill:#1e293b,stroke:#475569,color:#94a3b8
 ```
 
@@ -1070,6 +1087,105 @@ graph LR
     style Dev fill:#1e293b,stroke:#f59e0b,color:#e2e8f0
     style Prod fill:#1e293b,stroke:#10b981,color:#e2e8f0
 ```
+
+---
+
+## Observability Architecture
+
+### Coralogix Pipeline (Kubernetes)
+
+```mermaid
+graph TD
+    subgraph PODS["Application Pods"]
+        API_P["API Pod"]
+        WEB_P["Web Pod"]
+        MCP_P["MCP Pod"]
+        AI_P["Agentic AI Pod"]
+    end
+
+    subgraph OTEL["OTEL Collector DaemonSet"]
+        FL["filelog receiver<br/><i>pod log scraping</i>"]
+        PR["prometheus receiver<br/><i>metrics scraping</i>"]
+        KS["kubeletstats receiver<br/><i>node/pod/container</i>"]
+        OTLP_R["otlp receiver<br/><i>gRPC :4317 / HTTP :4318</i>"]
+        PROC["Processors<br/><i>memory_limiter → k8sattributes<br/>→ resource → batch</i>"]
+        EXP["Coralogix Exporter<br/><i>OTEL-native ingress</i>"]
+    end
+
+    CX_LOGS["Coralogix Logs"]
+    CX_METRICS["Coralogix Metrics"]
+    CX_TRACES["Coralogix Traces"]
+    DASH["Dashboards &amp; Alerts<br/><i>Terraform-managed</i>"]
+
+    API_P -. "stdout/stderr" .-> FL
+    WEB_P -. "stdout/stderr" .-> FL
+    MCP_P -. "stdout/stderr" .-> FL
+    AI_P -. "stdout/stderr" .-> FL
+    API_P -. "OTLP traces" .-> OTLP_R
+
+    FL --> PROC
+    PR --> PROC
+    KS --> PROC
+    OTLP_R --> PROC
+
+    PROC --> EXP
+    EXP -- "logs" --> CX_LOGS
+    EXP -- "metrics" --> CX_METRICS
+    EXP -- "traces" --> CX_TRACES
+
+    CX_LOGS --> DASH
+    CX_METRICS --> DASH
+    CX_TRACES --> DASH
+
+    style API_P fill:#10b981,color:#fff
+    style WEB_P fill:#0f172a,stroke:#6366f1,color:#e2e8f0
+    style MCP_P fill:#4f46e5,color:#fff
+    style AI_P fill:#cc785c,color:#fff
+    style EXP fill:#e11d48,color:#fff
+    style CX_LOGS fill:#e11d48,color:#fff
+    style CX_METRICS fill:#e11d48,color:#fff
+    style CX_TRACES fill:#e11d48,color:#fff
+    style DASH fill:#f59e0b,color:#000
+```
+
+### Coralogix Pipeline (Docker Compose)
+
+```mermaid
+graph LR
+    subgraph CONTAINERS["App Containers"]
+        C_API["api"]
+        C_WEB["web"]
+        C_MCP["mcp"]
+        C_AI["agentic-ai"]
+        C_NGINX["nginx"]
+    end
+
+    FB["Fluent Bit<br/><i>fluentd driver :24224</i>"]
+    OTELC["OTEL Collector<br/><i>docker_stats + otlp</i>"]
+    CX["Coralogix"]
+
+    C_API -- "fluentd" --> FB
+    C_WEB -- "fluentd" --> FB
+    C_MCP -- "fluentd" --> FB
+    C_AI -- "fluentd" --> FB
+    C_NGINX -- "fluentd" --> FB
+
+    FB -- "HTTP/TLS (logs)" --> CX
+    OTELC -- "OTEL (metrics + traces)" --> CX
+
+    style FB fill:#e11d48,color:#fff
+    style OTELC fill:#e11d48,color:#fff
+    style CX fill:#e11d48,color:#fff
+```
+
+### Terraform-Managed Coralogix Resources
+
+| Resource Type | Count | Purpose |
+|--------------|-------|---------|
+| Alert rules | 7 | 5xx spikes, error rate, service down, slow API, MongoDB failures, auth brute force, memory pressure |
+| TCO policies | 3 | Log tiering (high/medium/low priority) for cost optimization |
+| Parsing rules | 4 | JSON auto-parse, severity/timestamp/subsystem extraction |
+| Dashboard | 1 | 5 sections, 11 widgets (health, latency, log volume, MongoDB, auth) |
 
 ---
 

--- a/DEVOPS.md
+++ b/DEVOPS.md
@@ -1378,18 +1378,35 @@ WealthWise ships logs, metrics, and traces to **Coralogix** via OpenTelemetry Co
 
 #### Architecture
 
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                   OpenTelemetry Collector (DaemonSet)             │
-│                                                                    │
-│  Receivers               Processors            Exporter            │
-│  ┌─────────┐            ┌──────────────┐      ┌───────────────┐  │
-│  │ filelog  │─ logs ────▶│memory_limiter│─────▶│               │  │
-│  │ otlp    │─ traces ──▶│k8sattributes │─────▶│   Coralogix   │  │
-│  │ prom    │─ metrics ──▶│resource      │─────▶│ (OTEL native) │  │
-│  │ kubelet │────────────▶│batch         │─────▶│               │  │
-│  └─────────┘            └──────────────┘      └───────────────┘  │
-└──────────────────────────────────────────────────────────────────┘
+```mermaid
+graph LR
+    subgraph Receivers
+        FL["filelog<br/><i>pod logs</i>"]
+        OTLP["otlp<br/><i>gRPC + HTTP</i>"]
+        PROM["prometheus<br/><i>pod scraping</i>"]
+        KS["kubeletstats<br/><i>node metrics</i>"]
+    end
+
+    subgraph Processors
+        ML["memory_limiter"]
+        K8S["k8sattributes"]
+        RES["resource<br/><i>cx.application.name<br/>cx.subsystem.name</i>"]
+        BAT["batch"]
+    end
+
+    CX["Coralogix<br/><i>OTEL-native endpoint</i>"]
+
+    FL -- "logs" --> ML
+    OTLP -- "traces" --> ML
+    PROM -- "metrics" --> ML
+    KS -- "metrics" --> ML
+    ML --> K8S --> RES --> BAT --> CX
+
+    style FL fill:#10b981,color:#fff
+    style OTLP fill:#6366f1,color:#fff
+    style PROM fill:#f59e0b,color:#000
+    style KS fill:#f59e0b,color:#000
+    style CX fill:#e11d48,color:#fff
 ```
 
 #### Configuration by Deployment Target

--- a/DEVOPS.md
+++ b/DEVOPS.md
@@ -42,6 +42,7 @@ Comprehensive documentation of all DevOps, infrastructure, and operational conce
   - [Production Deployment](#production-deployment)
   - [Rollback Procedures](#rollback-procedures)
 - [Logging & Observability](#logging--observability)
+  - [Coralogix Integration](#coralogix-integration)
 - [Resource Limits & Scaling](#resource-limits--scaling)
 - [Troubleshooting](#troubleshooting)
 - [Operational Runbook](#operational-runbook)
@@ -1370,6 +1371,94 @@ docker compose -f docker-compose.production.yml logs -f mongodb
 # Last N lines
 docker compose -f docker-compose.production.yml logs --tail 100 api
 ```
+
+### Coralogix Integration
+
+WealthWise ships logs, metrics, and traces to **Coralogix** via OpenTelemetry Collector for centralized observability across all deployment targets.
+
+#### Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                   OpenTelemetry Collector (DaemonSet)             │
+│                                                                    │
+│  Receivers               Processors            Exporter            │
+│  ┌─────────┐            ┌──────────────┐      ┌───────────────┐  │
+│  │ filelog  │─ logs ────▶│memory_limiter│─────▶│               │  │
+│  │ otlp    │─ traces ──▶│k8sattributes │─────▶│   Coralogix   │  │
+│  │ prom    │─ metrics ──▶│resource      │─────▶│ (OTEL native) │  │
+│  │ kubelet │────────────▶│batch         │─────▶│               │  │
+│  └─────────┘            └──────────────┘      └───────────────┘  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+#### Configuration by Deployment Target
+
+| Target | Logs | Metrics | Traces | Config Path |
+|--------|------|---------|--------|-------------|
+| **Kubernetes (Helm)** | OTEL filelog receiver | OTEL Prometheus + kubeletstats | OTEL OTLP receiver | `helm/wealthwise/values.yaml` → `coralogix:` |
+| **Kubernetes (Kustomize)** | OTEL filelog receiver | OTEL Prometheus + kubeletstats | OTEL OTLP receiver | `k8s/base/otel-collector-*` |
+| **Docker Compose** | Fluent Bit (fluentd driver) | OTEL docker_stats | OTEL OTLP receiver | `coralogix/` + `docker-compose.production.yml` |
+| **Terraform (AWS)** | Managed via Coralogix provider | Alert rules + dashboards | — | `terraform/modules/coralogix/` |
+
+#### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `CX_API_KEY` | Yes | Coralogix Send-Your-Data API key |
+| `CX_DOMAIN` | Yes | Region endpoint: `coralogix.us`, `coralogix.com`, `eu2.coralogix.com`, `coralogix.in`, `coralogix.sg` |
+
+**Never commit `CX_API_KEY`.** Use K8s Secrets, Sealed Secrets, or CI/CD secret injection.
+
+#### Docker Compose Quick Start
+
+```bash
+# Set Coralogix credentials
+export CX_API_KEY="your-send-your-data-key"
+export CX_DOMAIN="coralogix.us"
+
+# Start with observability
+docker compose -f docker-compose.production.yml up -d
+
+# Verify Fluent Bit health
+curl -s http://localhost:2020/api/v1/health
+
+# Verify OTEL Collector health
+curl -s http://localhost:13133/
+```
+
+#### Kubernetes (Helm) Quick Start
+
+```bash
+# Install with Coralogix enabled
+helm upgrade --install wealthwise ./helm/wealthwise \
+  --set coralogix.enabled=true \
+  --set coralogix.apiKey="your-key" \
+  --set coralogix.domain="coralogix.us" \
+  -f helm/wealthwise/values-production.yaml
+
+# Verify OTEL Collector pods
+kubectl get pods -n wealthwise -l app.kubernetes.io/component=observability
+```
+
+#### Terraform (Alerts & Dashboards)
+
+```bash
+cd terraform/environments/production
+
+# Set Coralogix variables
+export TF_VAR_coralogix_api_key="your-alerts-rules-tags-api-key"
+export TF_VAR_coralogix_domain="coralogix.us"
+
+terraform plan
+terraform apply
+```
+
+This provisions 7 alert rules (5xx spikes, error rate, service down, slow API, MongoDB failures, auth brute force, memory pressure), 3 TCO log tiering policies, 4 parsing rule groups, and a 5-section dashboard.
+
+#### Nginx JSON Logging
+
+Production Nginx uses structured JSON logging (`json_combined` format) for automatic parsing in Coralogix — no custom regex needed. Fields include `request_method`, `status`, `request_time`, `upstream_response_time`, `ssl_protocol`, and more.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 [![Helm](https://img.shields.io/badge/Helm-0F1689?logo=helm&logoColor=white)](https://helm.sh/)
 [![Kustomize](https://img.shields.io/badge/Kustomize-326CE5?logo=kubernetes&logoColor=white)](https://kustomize.io/)
 [![Terraform](https://img.shields.io/badge/Terraform-7B42BC?logo=terraform&logoColor=white)](https://www.terraform.io/)
-[![AWS](https://img.shields.io/badge/AWS-232F3E?logo=amazonaws&logoColor=white)](https://aws.amazon.com/)
+[![Coralogix](https://img.shields.io/badge/Coralogix-DB2828?logo=datadog&logoColor=white)](https://coralogix.com/)
+[![AWS](https://img.shields.io/badge/Amazon_Web_Services-232F3E?logo=task&logoColor=white)](https://aws.amazon.com/)
 [![ECS Fargate](https://img.shields.io/badge/ECS_Fargate-FF9900?logo=amazonaws&logoColor=white)](https://aws.amazon.com/fargate/)
 [![CloudFormation](https://img.shields.io/badge/CloudFormation-FF4F8B?logo=amazonaws&logoColor=white)](https://aws.amazon.com/cloudformation/)
 [![DocumentDB](https://img.shields.io/badge/DocumentDB-C925D1?logo=amazonaws&logoColor=white)](https://aws.amazon.com/documentdb/)
@@ -51,7 +52,7 @@
 [![Anthropic Claude](https://img.shields.io/badge/Claude-Anthropic-cc785c?logo=anthropic&logoColor=white)](https://anthropic.com/)
 [![Google Gemini](https://img.shields.io/badge/Gemini-Google-4285f4?logo=google&logoColor=white)](https://ai.google.dev/gemini)
 [![Pino](https://img.shields.io/badge/Pino-9-687634)](https://getpino.io/)
-[![esbuild](https://img.shields.io/badge/esbuild-0.27-ffcf00?logo=esbuild&logoColor=black)](https://esbuild.github.io/)
+[![esbuild](https://img.shields.io/badge/esbuild-0.27-ffcf00?logo=esbuild&logoColor=white)](https://esbuild.github.io/)
 
 A full-stack personal finance application built with a **Turborepo monorepo**, featuring an **Express REST API**, a **Next.js 14** frontend, and **shared Zod schemas** for end-to-end type safety. Track accounts, transactions, categories, budgets, goals, recurring bills, and analytics with a responsive interface, CSV import, and polished dashboard workflows.
 

--- a/README.md
+++ b/README.md
@@ -883,6 +883,7 @@ Reusable modules in `terraform/modules/`:
 | `compute` | ECS Fargate cluster, task definitions, autoscaling |
 | `database` | DocumentDB cluster, security groups, encryption |
 | `monitoring` | CloudWatch dashboards, alarms, SNS notifications |
+| `coralogix` | Coralogix alerts, TCO policies, parsing rules, dashboards |
 | `dns` | Route53 hosted zone, ACM certificate, DNS records |
 | `container-registry` | ECR repositories, lifecycle policies, scanning |
 
@@ -899,6 +900,17 @@ Environments: `terraform/environments/{dev,staging,production}/`
 
 Each provider directory includes IaC templates, deployment scripts, and secret management setup. See the README in each directory for provider-specific instructions.
 
+### Observability (Coralogix)
+
+Centralized logs, metrics, and traces via **Coralogix** + **OpenTelemetry Collector**:
+
+- **Kubernetes**: OTEL Collector DaemonSet (filelog, Prometheus scraping, kubeletstats, OTLP receiver) with Coralogix exporter — deployed via Helm or Kustomize
+- **Docker Compose**: Fluent Bit log shipper + OTEL Collector for container metrics and traces
+- **Terraform**: 7 alert rules, 3 TCO log tiering policies, 4 parsing rule groups, and a 5-section dashboard provisioned via the `coralogix/coralogix` Terraform provider
+- **Nginx**: Structured JSON access logs (`json_combined` format) for automatic parsing
+
+Config: `coralogix/`, `helm/wealthwise/values.yaml` → `coralogix:`, `k8s/base/otel-collector-*`, `terraform/modules/coralogix/`
+
 ### Production Nginx
 
 `nginx/nginx.prod.conf` provides:
@@ -906,6 +918,7 @@ Each provider directory includes IaC templates, deployment scripts, and secret m
 - Security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options)
 - Rate limiting (10 req/s API, 5 req/s auth endpoints)
 - Static asset caching (`/_next/static/` with immutable Cache-Control)
+- Structured JSON access logging for Coralogix/OTEL ingestion
 - HTTP → HTTPS redirect
 
 ### Utility Scripts
@@ -1050,6 +1063,7 @@ See [`.beads/README.md`](.beads/README.md) and [`.agent-sessions/README.md`](.ag
 | **In-App AI**      | Gemini via Google Generative Language API, Express 4 advisor service |
 | **Agentic AI**     | @anthropic-ai/sdk (Claude), MCP Client, Express 4   |
 | **AI Models**      | Gemini 2.5 Flash by default for `/advisor`, Claude Sonnet 4 for `agentic-ai` |
+| **Observability**  | Coralogix, OpenTelemetry Collector, Fluent Bit        |
 | **Deployment**     | Docker Compose, Nginx reverse proxy                  |
 
 ---

--- a/coralogix/fluent-bit.conf
+++ b/coralogix/fluent-bit.conf
@@ -1,0 +1,56 @@
+[SERVICE]
+    Flush         5
+    Daemon        Off
+    Log_Level     info
+    Parsers_File  /fluent-bit/etc/parsers.conf
+    HTTP_Server   On
+    HTTP_Listen   0.0.0.0
+    HTTP_Port     2020
+    Health_Check  On
+    HC_Errors_Count  5
+    HC_Retry_Failure_Count  5
+    HC_Period     60
+    storage.metrics  On
+
+[INPUT]
+    Name              forward
+    Listen            0.0.0.0
+    Port              24224
+    Buffer_Chunk_Size 1M
+    Buffer_Max_Size   6M
+    Tag               docker.*
+
+[FILTER]
+    Name          parser
+    Match         docker.*
+    Key_Name      log
+    Parser        json
+    Reserve_Data  On
+
+[FILTER]
+    Name          modify
+    Match         docker.*
+    Add           cx.application.name wealthwise
+    Add           environment production
+
+[FILTER]
+    Name          lua
+    Match         docker.*
+    script        /fluent-bit/etc/subsystem.lua
+    call          set_subsystem
+
+[OUTPUT]
+    Name                 http
+    Match                docker.*
+    Host                 ingress.${CX_DOMAIN}
+    Port                 443
+    URI                  /logs/v1/singles
+    Format               json_lines
+    Header               Authorization Bearer ${CX_API_KEY}
+    Header               Content-Type application/json
+    Compress             gzip
+    TLS                  On
+    TLS.Verify           On
+    Retry_Limit          5
+    net.keepalive        On
+    net.keepalive_idle_timeout  10

--- a/coralogix/otel-collector-config.yaml
+++ b/coralogix/otel-collector-config.yaml
@@ -1,0 +1,80 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+      http:
+        endpoint: "0.0.0.0:4318"
+
+  docker_stats:
+    endpoint: unix:///var/run/docker.sock
+    collection_interval: 30s
+    timeout: 10s
+    api_version: 1.24
+    container_labels_to_metric_labels:
+      com.docker.compose.service: service_name
+    provide_per_core_cpu_metrics: false
+
+processors:
+  batch:
+    send_batch_size: 1024
+    timeout: 5s
+
+  memory_limiter:
+    check_interval: 5s
+    limit_percentage: 80
+    spike_limit_percentage: 25
+
+  resource:
+    attributes:
+      - key: cx.application.name
+        value: "wealthwise"
+        action: upsert
+      - key: environment
+        value: "production"
+        action: upsert
+
+  resource/subsystem:
+    attributes:
+      - key: cx.subsystem.name
+        from_attribute: service_name
+        action: upsert
+
+exporters:
+  coralogix:
+    domain: "${CX_DOMAIN}"
+    private_key: "${CX_API_KEY}"
+    application_name: "wealthwise"
+    subsystem_name: "docker"
+    timeout: 30s
+
+extensions:
+  health_check:
+    endpoint: "0.0.0.0:13133"
+
+service:
+  extensions:
+    - health_check
+  pipelines:
+    metrics:
+      receivers:
+        - docker_stats
+      processors:
+        - memory_limiter
+        - resource
+        - resource/subsystem
+        - batch
+      exporters:
+        - coralogix
+    traces:
+      receivers:
+        - otlp
+      processors:
+        - memory_limiter
+        - resource
+        - batch
+      exporters:
+        - coralogix
+  telemetry:
+    logs:
+      level: warn

--- a/coralogix/parsers.conf
+++ b/coralogix/parsers.conf
@@ -1,0 +1,18 @@
+[PARSER]
+    Name        json
+    Format      json
+    Time_Key    timestamp
+    Time_Format %Y-%m-%dT%H:%M:%S.%LZ
+    Time_Keep   On
+
+[PARSER]
+    Name        nginx_json
+    Format      json
+    Time_Key    time_local
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name        docker
+    Format      json
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%LZ

--- a/coralogix/subsystem.lua
+++ b/coralogix/subsystem.lua
@@ -1,0 +1,21 @@
+function set_subsystem(tag, timestamp, record)
+    local container = record["container_name"] or ""
+    if string.find(container, "api") then
+        record["cx.subsystem.name"] = "api"
+    elseif string.find(container, "web") then
+        record["cx.subsystem.name"] = "web"
+    elseif string.find(container, "mcp") then
+        record["cx.subsystem.name"] = "mcp"
+    elseif string.find(container, "agentic") then
+        record["cx.subsystem.name"] = "agentic-ai"
+    elseif string.find(container, "nginx") then
+        record["cx.subsystem.name"] = "nginx"
+    elseif string.find(container, "mongo") then
+        record["cx.subsystem.name"] = "mongodb"
+    elseif string.find(container, "otel") then
+        record["cx.subsystem.name"] = "otel-collector"
+    else
+        record["cx.subsystem.name"] = "unknown"
+    end
+    return 1, timestamp, record
+end

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -48,6 +48,8 @@ services:
     depends_on:
       mongodb:
         condition: service_healthy
+      fluent-bit:
+        condition: service_healthy
     networks:
       - wealthwise-network
     restart: always
@@ -68,10 +70,13 @@ services:
           cpus: "0.25"
           memory: 128M
     logging:
-      driver: json-file
+      driver: fluentd
       options:
-        max-size: "10m"
-        max-file: "3"
+        fluentd-address: "localhost:24224"
+        fluentd-async: "true"
+        fluentd-retry-wait: "1s"
+        fluentd-max-retries: "30"
+        tag: "docker.{{.Name}}"
 
   web:
     build:
@@ -88,6 +93,8 @@ services:
       - API_URL=http://api:4000
     depends_on:
       api:
+        condition: service_healthy
+      fluent-bit:
         condition: service_healthy
     networks:
       - wealthwise-network
@@ -109,10 +116,13 @@ services:
           cpus: "0.25"
           memory: 128M
     logging:
-      driver: json-file
+      driver: fluentd
       options:
-        max-size: "10m"
-        max-file: "3"
+        fluentd-address: "localhost:24224"
+        fluentd-async: "true"
+        fluentd-retry-wait: "1s"
+        fluentd-max-retries: "30"
+        tag: "docker.{{.Name}}"
 
   mcp:
     build:
@@ -129,6 +139,8 @@ services:
       - MCP_PORT=5100
     depends_on:
       mongodb:
+        condition: service_healthy
+      fluent-bit:
         condition: service_healthy
     networks:
       - wealthwise-network
@@ -150,10 +162,13 @@ services:
           cpus: "0.25"
           memory: 128M
     logging:
-      driver: json-file
+      driver: fluentd
       options:
-        max-size: "10m"
-        max-file: "3"
+        fluentd-address: "localhost:24224"
+        fluentd-async: "true"
+        fluentd-retry-wait: "1s"
+        fluentd-max-retries: "30"
+        tag: "docker.{{.Name}}"
 
   agentic-ai:
     build:
@@ -170,6 +185,8 @@ services:
       - AGENT_PORT=5200
     depends_on:
       mcp:
+        condition: service_healthy
+      fluent-bit:
         condition: service_healthy
     networks:
       - wealthwise-network
@@ -191,10 +208,13 @@ services:
           cpus: "0.25"
           memory: 128M
     logging:
-      driver: json-file
+      driver: fluentd
       options:
-        max-size: "10m"
-        max-file: "3"
+        fluentd-address: "localhost:24224"
+        fluentd-async: "true"
+        fluentd-retry-wait: "1s"
+        fluentd-max-retries: "30"
+        tag: "docker.{{.Name}}"
 
   nginx:
     image: nginx:alpine
@@ -214,6 +234,8 @@ services:
         condition: service_healthy
       agentic-ai:
         condition: service_healthy
+      fluent-bit:
+        condition: service_healthy
     networks:
       - wealthwise-network
     restart: always
@@ -232,10 +254,84 @@ services:
           cpus: "0.1"
           memory: 64M
     logging:
+      driver: fluentd
+      options:
+        fluentd-address: "localhost:24224"
+        fluentd-async: "true"
+        fluentd-retry-wait: "1s"
+        fluentd-max-retries: "30"
+        tag: "docker.{{.Name}}"
+
+  # ── Coralogix: Log Shipper ──────────────────────────────────────────────────
+  fluent-bit:
+    image: fluent/fluent-bit:3.0
+    container_name: wealthwise-fluent-bit
+    volumes:
+      - ./coralogix/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf:ro
+      - ./coralogix/parsers.conf:/fluent-bit/etc/parsers.conf:ro
+      - ./coralogix/subsystem.lua:/fluent-bit/etc/subsystem.lua:ro
+    environment:
+      - CX_API_KEY=${CX_API_KEY}
+      - CX_DOMAIN=${CX_DOMAIN:-coralogix.us}
+    networks:
+      - wealthwise-network
+    restart: always
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:2020/api/v1/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 64M
+    logging:
       driver: json-file
       options:
-        max-size: "10m"
-        max-file: "3"
+        max-size: "5m"
+        max-file: "2"
+
+  # ── Coralogix: OpenTelemetry Collector (Metrics + Traces) ───────────────────
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.96.0
+    container_name: wealthwise-otel-collector
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./coralogix/otel-collector-config.yaml:/etc/otelcol/config.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - CX_API_KEY=${CX_API_KEY}
+      - CX_DOMAIN=${CX_DOMAIN:-coralogix.us}
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    networks:
+      - wealthwise-network
+    restart: always
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:13133/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
 
 volumes:
   mongodb_data_prod:

--- a/helm/wealthwise/templates/coralogix-secret.yaml
+++ b/helm/wealthwise/templates/coralogix-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.coralogix.enabled .Values.coralogix.apiKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-coralogix
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: observability
+type: Opaque
+data:
+  CX_API_KEY: {{ .Values.coralogix.apiKey | b64enc | quote }}
+{{- end }}

--- a/helm/wealthwise/templates/networkpolicy-otel-egress.yaml
+++ b/helm/wealthwise/templates/networkpolicy-otel-egress.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.coralogix.enabled .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-allow-otel-egress
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: observability
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "wealthwise.fullname" . }}-otel-collector
+      app.kubernetes.io/component: observability
+  policyTypes:
+    - Egress
+  egress:
+    # Allow HTTPS egress to Coralogix endpoints
+    - ports:
+        - protocol: TCP
+          port: 443
+    # Allow DNS resolution
+    - ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+    # Allow kubelet stats collection
+    - ports:
+        - protocol: TCP
+          port: 10250
+    # Allow scraping application metrics within the namespace
+    - to:
+        - podSelector: {}
+{{- end }}

--- a/helm/wealthwise/templates/otel-collector-configmap.yaml
+++ b/helm/wealthwise/templates/otel-collector-configmap.yaml
@@ -1,0 +1,229 @@
+{{- if .Values.coralogix.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-otel-collector
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: observability
+data:
+  otel-collector-config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:{{ .Values.coralogix.otelCollector.ports.otlpGrpc }}"
+          http:
+            endpoint: "0.0.0.0:{{ .Values.coralogix.otelCollector.ports.otlpHttp }}"
+
+      filelog:
+        include:
+          - /var/log/pods/{{ include "wealthwise.namespace" . }}_*/*/*.log
+        exclude:
+          - /var/log/pods/{{ include "wealthwise.namespace" . }}_*otel-collector*/*/*.log
+        start_at: end
+        include_file_path: true
+        include_file_name: false
+        operators:
+          - type: router
+            id: get-format
+            routes:
+              - output: parser-docker
+                expr: 'body matches "^\\{"'
+              - output: parser-containerd
+                expr: 'body matches "^[^ Z]+Z"'
+          - type: json_parser
+            id: parser-docker
+            output: extract-metadata
+            timestamp:
+              parse_from: attributes.time
+              layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+          - type: regex_parser
+            id: parser-containerd
+            regex: "^(?P<time>[^ Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$"
+            output: extract-metadata
+            timestamp:
+              parse_from: attributes.time
+              layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+          - type: move
+            id: extract-metadata
+            from: attributes["log.file.path"]
+            to: resource["log.file.path"]
+          - type: regex_parser
+            id: extract-metadata-from-filepath
+            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/.*$'
+            parse_from: resource["log.file.path"]
+            cache:
+              size: 128
+          - type: move
+            from: attributes.container_name
+            to: resource["k8s.container.name"]
+          - type: move
+            from: attributes.namespace
+            to: resource["k8s.namespace.name"]
+          - type: move
+            from: attributes.pod_name
+            to: resource["k8s.pod.name"]
+
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: "wealthwise-services"
+              scrape_interval: {{ .Values.coralogix.otelCollector.scrapeInterval }}
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces:
+                    names:
+                      - {{ include "wealthwise.namespace" . }}
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: "true"
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                  action: replace
+                  target_label: __metrics_path__
+                  regex: (.+)
+                - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+                  action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $$1:$$2
+                  target_label: __address__
+                - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+                  action: replace
+                  target_label: service
+                - source_labels: [__meta_kubernetes_namespace]
+                  action: replace
+                  target_label: namespace
+
+      k8s_cluster:
+        collection_interval: 30s
+        node_conditions_to_report:
+          - Ready
+          - MemoryPressure
+          - DiskPressure
+        allocatable_types_to_report:
+          - cpu
+          - memory
+
+      kubeletstats:
+        collection_interval: 30s
+        auth_type: serviceAccount
+        endpoint: "https://${env:K8S_NODE_NAME}:10250"
+        insecure_skip_verify: true
+        metric_groups:
+          - node
+          - pod
+          - container
+
+    processors:
+      batch:
+        send_batch_size: 1024
+        timeout: 5s
+
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+
+      k8sattributes:
+        auth_type: "serviceAccount"
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.node.name
+            - k8s.container.name
+          labels:
+            - tag_name: app
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: component
+              key: app.kubernetes.io/component
+              from: pod
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: connection
+
+      resource:
+        attributes:
+          - key: cx.application.name
+            value: {{ .Values.coralogix.applicationName }}
+            action: upsert
+          - key: cx.subsystem.name
+            from_attribute: app
+            action: upsert
+          - key: environment
+            value: {{ .Values.config.nodeEnv }}
+            action: upsert
+
+      transform/logs:
+        log_statements:
+          - context: log
+            statements:
+              - set(severity_text, "INFO") where severity_text == ""
+              - set(body, attributes["log"]) where attributes["log"] != nil
+
+    exporters:
+      coralogix:
+        domain: {{ .Values.coralogix.domain | quote }}
+        private_key: "${env:CX_API_KEY}"
+        application_name: {{ .Values.coralogix.applicationName | quote }}
+        subsystem_name: "kubernetes"
+        timeout: 30s
+
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:{{ .Values.coralogix.otelCollector.ports.healthCheck }}"
+
+    service:
+      extensions:
+        - health_check
+      pipelines:
+        logs:
+          receivers:
+            - filelog
+          processors:
+            - memory_limiter
+            - k8sattributes
+            - resource
+            - transform/logs
+            - batch
+          exporters:
+            - coralogix
+        metrics:
+          receivers:
+            - prometheus
+            - kubeletstats
+            - k8s_cluster
+          processors:
+            - memory_limiter
+            - k8sattributes
+            - resource
+            - batch
+          exporters:
+            - coralogix
+        traces:
+          receivers:
+            - otlp
+          processors:
+            - memory_limiter
+            - k8sattributes
+            - resource
+            - batch
+          exporters:
+            - coralogix
+      telemetry:
+        logs:
+          level: warn
+        metrics:
+          address: "0.0.0.0:8888"
+{{- end }}

--- a/helm/wealthwise/templates/otel-collector-daemonset.yaml
+++ b/helm/wealthwise/templates/otel-collector-daemonset.yaml
@@ -1,0 +1,170 @@
+{{- if and .Values.coralogix.enabled .Values.coralogix.otelCollector.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-otel-collector
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-otel-collector
+  labels:
+    {{- include "wealthwise.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: observability
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - nodes/stats
+      - namespaces
+      - endpoints
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - replicasets
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs:
+      - "/metrics"
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-otel-collector
+  labels:
+    {{- include "wealthwise.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: observability
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "wealthwise.fullname" . }}-otel-collector
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "wealthwise.fullname" . }}-otel-collector
+    namespace: {{ include "wealthwise.namespace" . }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "wealthwise.fullname" . }}-otel-collector
+  namespace: {{ include "wealthwise.namespace" . }}
+  labels:
+    {{- include "wealthwise.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/name: {{ include "wealthwise.fullname" . }}-otel-collector
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "wealthwise.fullname" . }}-otel-collector
+      app.kubernetes.io/component: observability
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/otel-collector-configmap.yaml") . | sha256sum }}
+      labels:
+        app.kubernetes.io/name: {{ include "wealthwise.fullname" . }}-otel-collector
+        app.kubernetes.io/component: observability
+        {{- include "wealthwise.commonLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "wealthwise.fullname" . }}-otel-collector
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: otel-collector
+          image: "{{ .Values.coralogix.otelCollector.image.repository }}:{{ .Values.coralogix.otelCollector.image.tag }}"
+          imagePullPolicy: {{ .Values.coralogix.otelCollector.image.pullPolicy }}
+          args:
+            - "--config=/etc/otelcol/otel-collector-config.yaml"
+          env:
+            - name: CX_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wealthwise.fullname" . }}-coralogix
+                  key: CX_API_KEY
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - name: otlp-grpc
+              containerPort: {{ .Values.coralogix.otelCollector.ports.otlpGrpc }}
+              protocol: TCP
+            - name: otlp-http
+              containerPort: {{ .Values.coralogix.otelCollector.ports.otlpHttp }}
+              protocol: TCP
+            - name: fluent-forward
+              containerPort: {{ .Values.coralogix.otelCollector.ports.fluentForward }}
+              protocol: TCP
+            - name: health-check
+              containerPort: {{ .Values.coralogix.otelCollector.ports.healthCheck }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: health-check
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: health-check
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.coralogix.otelCollector.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: otel-config
+              mountPath: /etc/otelcol
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      volumes:
+        - name: otel-config
+          configMap:
+            name: {{ include "wealthwise.fullname" . }}-otel-collector
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+{{- end }}

--- a/helm/wealthwise/values-dev.yaml
+++ b/helm/wealthwise/values-dev.yaml
@@ -43,3 +43,6 @@ ingress:
 
 networkPolicies:
   enabled: false
+
+coralogix:
+  enabled: false

--- a/helm/wealthwise/values-production.yaml
+++ b/helm/wealthwise/values-production.yaml
@@ -20,3 +20,17 @@ web:
     limits:
       memory: "1Gi"
       cpu: "1000m"
+
+coralogix:
+  enabled: true
+  domain: "coralogix.us"
+  applicationName: "wealthwise"
+  otelCollector:
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "500m"
+      limits:
+        memory: "1Gi"
+        cpu: "1000m"
+    scrapeInterval: "15s"

--- a/helm/wealthwise/values-staging.yaml
+++ b/helm/wealthwise/values-staging.yaml
@@ -9,3 +9,16 @@ ingress:
 web:
   nextauthUrl: "https://staging.wealthwise.example.com"
   nextPublicApiUrl: "https://staging.wealthwise.example.com/api/v1"
+
+coralogix:
+  enabled: true
+  domain: "coralogix.us"
+  applicationName: "wealthwise-staging"
+  otelCollector:
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "256Mi"
+        cpu: "250m"

--- a/helm/wealthwise/values.yaml
+++ b/helm/wealthwise/values.yaml
@@ -218,3 +218,47 @@ ingress:
 networkPolicies:
   enabled: true
   mongodbPort: 27017
+
+# ---- Coralogix Observability ----
+
+coralogix:
+  enabled: true
+
+  # Coralogix ingress domain (region-specific)
+  # Options: coralogix.com (EU1), coralogix.us (US1), eu2.coralogix.com (EU2),
+  #          coralogix.in (AP1), coralogix.sg (AP2)
+  domain: "coralogix.us"
+
+  # Coralogix Send-Your-Data API key — stored in a Secret.
+  # Set via --set coralogix.apiKey=xxx or use existingSecret.
+  apiKey: ""
+
+  # Application and subsystem names shown in Coralogix UI
+  applicationName: "wealthwise"
+
+  # OpenTelemetry Collector DaemonSet
+  otelCollector:
+    enabled: true
+
+    image:
+      repository: otel/opentelemetry-collector-contrib
+      tag: "0.96.0"
+      pullPolicy: IfNotPresent
+
+    resources:
+      requests:
+        memory: "256Mi"
+        cpu: "200m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"
+
+    # Ports exposed by the collector
+    ports:
+      otlpGrpc: 4317
+      otlpHttp: 4318
+      fluentForward: 8006
+      healthCheck: 13133
+
+    # Scrape interval for Prometheus metrics
+    scrapeInterval: "30s"

--- a/k8s/base/coralogix-secret.yaml
+++ b/k8s/base/coralogix-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wealthwise-coralogix
+  namespace: wealthwise
+  labels:
+    app.kubernetes.io/part-of: wealthwise
+    app.kubernetes.io/component: observability
+type: Opaque
+stringData:
+  CX_API_KEY: "REPLACE_WITH_CORALOGIX_API_KEY"
+  CX_DOMAIN: "coralogix.us"

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -24,6 +24,13 @@ resources:
   - agentic-ai-pdb.yaml
   - ingress.yaml
   - network-policy.yaml
+  - coralogix-secret.yaml
+  - otel-collector-configmap.yaml
+  - otel-collector-rbac.yaml
+  - otel-collector-daemonset.yaml
+  - otel-collector-service.yaml
+  - networkpolicy-otel-egress.yaml
+  - networkpolicy-otel-ingress.yaml
 
 commonLabels:
   app.kubernetes.io/part-of: wealthwise

--- a/k8s/base/networkpolicy-otel-egress.yaml
+++ b/k8s/base/networkpolicy-otel-egress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: wealthwise-otel-collector-egress
+  namespace: wealthwise
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: wealthwise-otel-collector
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+    - ports:
+        - port: 10250
+          protocol: TCP
+    - to:
+        - namespaceSelector: {}
+          podSelector: {}
+      ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP

--- a/k8s/base/networkpolicy-otel-ingress.yaml
+++ b/k8s/base/networkpolicy-otel-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: wealthwise-otel-collector-ingress
+  namespace: wealthwise
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: wealthwise-otel-collector
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: wealthwise
+      ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP

--- a/k8s/base/otel-collector-configmap.yaml
+++ b/k8s/base/otel-collector-configmap.yaml
@@ -1,0 +1,217 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wealthwise-otel-collector-config
+  namespace: wealthwise
+  labels:
+    app.kubernetes.io/name: wealthwise-otel-collector
+    app.kubernetes.io/component: observability
+data:
+  otel-collector-config.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    receivers:
+      filelog:
+        include:
+          - /var/log/pods/wealthwise_*/*/*.log
+        exclude:
+          - /var/log/pods/wealthwise_wealthwise-otel-collector*/*/*.log
+        start_at: end
+        include_file_path: true
+        include_file_name: false
+        operators:
+          - type: router
+            id: log_format_router
+            routes:
+              - output: json_parser
+                expr: 'body matches "^\\{"'
+              - output: containerd_parser
+                expr: 'body matches "^\\d{4}-"'
+          - type: json_parser
+            id: json_parser
+            timestamp:
+              parse_from: attributes.time
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+          - type: regex_parser
+            id: containerd_parser
+            regex: '^(?P<time>[^ ]+) (?P<stream>stdout|stderr) (?P<flags>[^ ]*) (?P<log>.*)$'
+            timestamp:
+              parse_from: attributes.time
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+          - type: regex_parser
+            id: extract_metadata_from_filepath
+            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
+            parse_from: attributes["log.file.path"]
+          - type: move
+            from: attributes.log
+            to: body
+          - type: move
+            from: attributes.namespace
+            to: resource["k8s.namespace.name"]
+          - type: move
+            from: attributes.pod_name
+            to: resource["k8s.pod.name"]
+          - type: move
+            from: attributes.container_name
+            to: resource["k8s.container.name"]
+          - type: move
+            from: attributes.uid
+            to: resource["k8s.pod.uid"]
+
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: wealthwise-pods
+              scrape_interval: 30s
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces:
+                    names:
+                      - wealthwise
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: "true"
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                  action: replace
+                  target_label: __metrics_path__
+                  regex: (.+)
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
+                  action: replace
+                  target_label: __address__
+                  regex: (\d+);([\d\.]+)
+                  replacement: $${2}:$${1}
+                - source_labels: [__meta_kubernetes_namespace]
+                  action: replace
+                  target_label: namespace
+                - source_labels: [__meta_kubernetes_pod_name]
+                  action: replace
+                  target_label: pod
+                - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+                  action: replace
+                  target_label: app
+
+      kubeletstats:
+        collection_interval: 30s
+        auth_type: serviceAccount
+        endpoint: https://${env:K8S_NODE_NAME}:10250
+        insecure_skip_verify: true
+        metric_groups:
+          - node
+          - pod
+          - container
+
+    processors:
+      batch:
+        send_batch_size: 1024
+        timeout: 5s
+
+      memory_limiter:
+        limit_percentage: 80
+        spike_limit_percentage: 25
+        check_interval: 1s
+
+      k8sattributes:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.node.name
+            - k8s.container.name
+          labels:
+            - tag_name: app.kubernetes.io/name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: app.kubernetes.io/component
+              key: app.kubernetes.io/component
+              from: pod
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+
+      resource:
+        attributes:
+          - key: cx.application.name
+            value: wealthwise
+            action: upsert
+          - key: cx.subsystem.name
+            from_attribute: app.kubernetes.io/name
+            action: upsert
+
+      transform/logs:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - set(severity_text, "INFO") where severity_text == ""
+              - set(severity_number, 9) where severity_number == 0
+              - set(body, attributes["log"]) where body == "" and attributes["log"] != nil
+
+    exporters:
+      coralogix:
+        domain: "${CX_DOMAIN}"
+        private_key: "${CX_API_KEY}"
+        application_name: "wealthwise"
+        subsystem_name: "kubernetes"
+        timeout: 30s
+
+    service:
+      extensions:
+        - health_check
+      pipelines:
+        logs:
+          receivers:
+            - filelog
+          processors:
+            - memory_limiter
+            - k8sattributes
+            - resource
+            - transform/logs
+            - batch
+          exporters:
+            - coralogix
+        metrics:
+          receivers:
+            - prometheus
+            - kubeletstats
+          processors:
+            - memory_limiter
+            - k8sattributes
+            - resource
+            - batch
+          exporters:
+            - coralogix
+        traces:
+          receivers:
+            - otlp
+          processors:
+            - memory_limiter
+            - k8sattributes
+            - resource
+            - batch
+          exporters:
+            - coralogix
+      telemetry:
+        logs:
+          level: info
+        metrics:
+          address: 0.0.0.0:8888

--- a/k8s/base/otel-collector-daemonset.yaml
+++ b/k8s/base/otel-collector-daemonset.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: wealthwise-otel-collector
+  namespace: wealthwise
+  labels:
+    app.kubernetes.io/name: wealthwise-otel-collector
+    app.kubernetes.io/component: observability
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wealthwise-otel-collector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: wealthwise-otel-collector
+        app.kubernetes.io/component: observability
+    spec:
+      serviceAccountName: wealthwise-otel-collector
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.96.0
+          args:
+            - "--config=/etc/otelcol/otel-collector-config.yaml"
+          env:
+            - name: CX_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: wealthwise-coralogix
+                  key: CX_API_KEY
+            - name: CX_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: wealthwise-coralogix
+                  key: CX_DOMAIN
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: health-check
+              containerPort: 13133
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: otel-collector-config
+              mountPath: /etc/otelcol
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      volumes:
+        - name: otel-collector-config
+          configMap:
+            name: wealthwise-otel-collector-config
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule

--- a/k8s/base/otel-collector-rbac.yaml
+++ b/k8s/base/otel-collector-rbac.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wealthwise-otel-collector
+  namespace: wealthwise
+  labels:
+    app.kubernetes.io/name: wealthwise-otel-collector
+    app.kubernetes.io/component: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wealthwise-otel-collector
+  labels:
+    app.kubernetes.io/name: wealthwise-otel-collector
+    app.kubernetes.io/component: observability
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+      - services
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - nodes/stats
+      - nodes/proxy
+    verbs:
+      - get
+  - apiGroups: ["apps"]
+    resources:
+      - replicasets
+      - deployments
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wealthwise-otel-collector
+  labels:
+    app.kubernetes.io/name: wealthwise-otel-collector
+    app.kubernetes.io/component: observability
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: wealthwise-otel-collector
+subjects:
+  - kind: ServiceAccount
+    name: wealthwise-otel-collector
+    namespace: wealthwise

--- a/k8s/base/otel-collector-service.yaml
+++ b/k8s/base/otel-collector-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wealthwise-otel-collector
+  namespace: wealthwise
+  labels:
+    app.kubernetes.io/name: wealthwise-otel-collector
+    app.kubernetes.io/component: observability
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: wealthwise-otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -11,6 +11,7 @@ patches:
   - path: web-deployment-patch.yaml
   - path: mcp-deployment-patch.yaml
   - path: agentic-ai-deployment-patch.yaml
+  - path: otel-collector-patch.yaml
   - target:
       kind: Ingress
       name: wealthwise-ingress

--- a/k8s/overlays/production/otel-collector-patch.yaml
+++ b/k8s/overlays/production/otel-collector-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: wealthwise-otel-collector
+spec:
+  template:
+    spec:
+      containers:
+        - name: otel-collector
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -14,12 +14,31 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    # Logging
-    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for" '
-                    'rt=$request_time';
-    access_log /var/log/nginx/access.log main;
+    # JSON log format for structured log ingestion (Coralogix / OTEL)
+    log_format json_combined escape=json
+        '{'
+            '"time_local":"$time_local",'
+            '"remote_addr":"$remote_addr",'
+            '"remote_user":"$remote_user",'
+            '"request":"$request",'
+            '"request_method":"$request_method",'
+            '"request_uri":"$request_uri",'
+            '"status":$status,'
+            '"body_bytes_sent":$body_bytes_sent,'
+            '"http_referer":"$http_referer",'
+            '"http_user_agent":"$http_user_agent",'
+            '"http_x_forwarded_for":"$http_x_forwarded_for",'
+            '"request_time":$request_time,'
+            '"upstream_response_time":"$upstream_response_time",'
+            '"upstream_addr":"$upstream_addr",'
+            '"ssl_protocol":"$ssl_protocol",'
+            '"ssl_cipher":"$ssl_cipher",'
+            '"request_length":$request_length,'
+            '"connection":$connection,'
+            '"connection_requests":$connection_requests,'
+            '"pipe":"$pipe"'
+        '}';
+    access_log /var/log/nginx/access.log json_combined;
 
     # Performance
     sendfile on;

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    coralogix = {
+      source  = "coralogix/coralogix"
+      version = "~> 2.0"
+    }
   }
 }
 
@@ -19,6 +23,11 @@ provider "aws" {
       ManagedBy   = "terraform"
     }
   }
+}
+
+provider "coralogix" {
+  api_key = var.coralogix_api_key
+  domain  = var.coralogix_domain
 }
 
 # --- IAM Roles for ECS ---
@@ -222,4 +231,14 @@ module "monitoring" {
   alarm_email                 = var.alarm_email
   cpu_threshold               = 70
   error_threshold             = 0.5
+}
+
+module "coralogix" {
+  source = "../../modules/coralogix"
+
+  environment         = var.environment
+  coralogix_api_key   = var.coralogix_api_key
+  coralogix_domain    = var.coralogix_domain
+  application_name    = "wealthwise"
+  notification_emails = [var.alarm_email]
 }

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -2,3 +2,7 @@ region        = "us-east-1"
 environment   = "production"
 alarm_email   = "prod-alerts@example.com"
 db_password   = "CHANGE_ME"
+
+# Coralogix — obtain API key from Settings > API Keys > Alerts, Rules & Tags API Key
+coralogix_api_key = "CHANGE_ME"
+coralogix_domain  = "coralogix.us"

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -20,3 +20,17 @@ variable "db_password" {
   type        = string
   sensitive   = true
 }
+
+# ── Coralogix ────────────────────────────────────────────────────────────────
+
+variable "coralogix_api_key" {
+  description = "Coralogix Alerts, Rules & Tags API key for the observability module"
+  type        = string
+  sensitive   = true
+}
+
+variable "coralogix_domain" {
+  description = "Coralogix platform domain matching your account region (coralogix.com, coralogix.us, eu2.coralogix.com, coralogix.in, coralogix.sg)"
+  type        = string
+  default     = "coralogix.us"
+}

--- a/terraform/modules/coralogix/main.tf
+++ b/terraform/modules/coralogix/main.tf
@@ -1,0 +1,1305 @@
+# -----------------------------------------------------------------------------
+# Coralogix Observability Module — WealthWise Finance Tracker
+#
+# Provisions log-tiering (TCO) policies, alerting rules, parsing pipelines,
+# dashboards, and notification integrations against the Coralogix platform.
+#
+# WealthWise services:
+#   api        — Express.js API   (port 4000)
+#   web        — Next.js frontend (port 3000)
+#   mcp        — MCP service      (port 5100)
+#   agentic-ai — Agentic AI       (port 5200)
+# -----------------------------------------------------------------------------
+
+# ─── Locals ──────────────────────────────────────────────────────────────────
+
+locals {
+  resource_prefix = "${var.project_name}-${var.environment}"
+
+  services = ["api", "web", "mcp", "agentic-ai"]
+
+  common_labels = {
+    managed_by  = "terraform"
+    project     = var.project_name
+    environment = var.environment
+  }
+
+  # Notification target flags — drive dynamic blocks in alert definitions
+  has_webhook = var.alert_webhook_url != ""
+  has_emails  = length(var.notification_emails) > 0
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 1. WEBHOOK INTEGRATION
+# ═════════════════════════════════════════════════════════════════════════════
+
+resource "coralogix_webhook" "alerts" {
+  count = local.has_webhook ? 1 : 0
+
+  name = "${local.resource_prefix}-alert-webhook"
+
+  custom {
+    url    = var.alert_webhook_url
+    method = "post"
+    headers = {
+      "Content-Type" = "application/json"
+    }
+    body = jsonencode({
+      alert_name  = "$ALERT_NAME"
+      severity    = "$ALERT_SEVERITY"
+      description = "$ALERT_DESCRIPTION"
+      timestamp   = "$EVENT_TIMESTAMP"
+      alert_url   = "$ALERT_URL"
+      log_url     = "$LOG_URL"
+      environment = var.environment
+      project     = var.project_name
+    })
+  }
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 2. TCO POLICIES — Log Tiering for Cost Optimization
+#
+# Coralogix TCO (Total Cost of Ownership) policies route logs to different
+# storage tiers.  High-priority logs are indexed for fast search; medium are
+# available with moderate latency; low are archived cheaply.
+# ═════════════════════════════════════════════════════════════════════════════
+
+resource "coralogix_tco_policy_logs" "high_priority" {
+  name        = "${local.resource_prefix}-high-priority"
+  description = "Index ERROR/CRITICAL severity logs from the API subsystem for real-time alerting"
+  priority    = "high"
+  order       = 1
+  enabled     = true
+
+  severities = ["error", "critical"]
+
+  applications {
+    rule_type = "is"
+    names     = [var.application_name]
+  }
+
+  subsystems {
+    rule_type = "is"
+    names     = ["api"]
+  }
+}
+
+resource "coralogix_tco_policy_logs" "medium_priority" {
+  name        = "${local.resource_prefix}-medium-priority"
+  description = "Retain WARN/INFO severity logs across all subsystems with moderate search latency"
+  priority    = "medium"
+  order       = 2
+  enabled     = true
+
+  severities = ["warning", "info"]
+
+  applications {
+    rule_type = "is"
+    names     = [var.application_name]
+  }
+}
+
+resource "coralogix_tco_policy_logs" "low_priority" {
+  name        = "${local.resource_prefix}-low-priority"
+  description = "Archive DEBUG logs from the web subsystem (static asset requests) for cost savings"
+  priority    = "low"
+  order       = 3
+  enabled     = true
+
+  severities = ["debug"]
+
+  applications {
+    rule_type = "is"
+    names     = [var.application_name]
+  }
+
+  subsystems {
+    rule_type = "is"
+    names     = ["web"]
+  }
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 3. ALERT RULES
+#
+# Seven production alerts covering error rates, latency, availability,
+# database connectivity, security, and resource saturation.
+# ═════════════════════════════════════════════════════════════════════════════
+
+# ── 3a. API 5xx Spike — Ratio Alert ─────────────────────────────────────────
+#
+# Fires when the ratio of HTTP 5xx responses to total API requests exceeds 5 %
+# within a rolling 5-minute window.
+
+resource "coralogix_alert" "api_5xx_spike" {
+  name        = "${local.resource_prefix}-api-5xx-spike"
+  description = "HTTP 5xx errors exceed 5 %% of all API requests in a 5-minute window"
+  severity    = "critical"
+  enabled     = true
+  labels      = local.common_labels
+
+  notification_group {
+    dynamic "notification" {
+      for_each = local.has_webhook ? [1] : []
+      content {
+        integration_id             = coralogix_webhook.alerts[0].id
+        notify_on                  = "triggered_and_resolved"
+        retriggering_period_minutes = 15
+      }
+    }
+
+    dynamic "notification" {
+      for_each = local.has_emails ? [1] : []
+      content {
+        recipients {
+          emails = var.notification_emails
+        }
+        notify_on                  = "triggered_and_resolved"
+        retriggering_period_minutes = 15
+      }
+    }
+  }
+
+  type_definition {
+    logs_ratio_threshold {
+      numerator_alias   = "5xx_errors"
+      denominator_alias = "all_api_requests"
+
+      rules {
+        condition {
+          threshold      = 5
+          time_window    = "5_minutes"
+          condition_type = "more_than"
+        }
+      }
+
+      numerator {
+        simple_filter {
+          lucene_query = "status:[500 TO 599]"
+          label_filters {
+            application_name {
+              rule_type = "is"
+              values    = [var.application_name]
+            }
+            subsystem_name {
+              rule_type = "is"
+              values    = ["api"]
+            }
+          }
+        }
+      }
+
+      denominator {
+        simple_filter {
+          lucene_query = "_exists_:status"
+          label_filters {
+            application_name {
+              rule_type = "is"
+              values    = [var.application_name]
+            }
+            subsystem_name {
+              rule_type = "is"
+              values    = ["api"]
+            }
+          }
+        }
+      }
+
+      notification_payload_filter = ["coralogix.metadata.subsystemName", "status"]
+    }
+  }
+}
+
+# ── 3b. High Error Rate — Threshold Alert ───────────────────────────────────
+#
+# Fires when more than 50 error-severity logs are observed across any
+# subsystem in 5 minutes.
+
+resource "coralogix_alert" "high_error_rate" {
+  name        = "${local.resource_prefix}-high-error-rate"
+  description = "More than 50 error-severity logs in 5 minutes across any subsystem"
+  severity    = "error"
+  enabled     = true
+  labels      = local.common_labels
+
+  notification_group {
+    group_by_fields = ["coralogix.metadata.subsystemName"]
+
+    dynamic "notification" {
+      for_each = local.has_webhook ? [1] : []
+      content {
+        integration_id             = coralogix_webhook.alerts[0].id
+        notify_on                  = "triggered_and_resolved"
+        retriggering_period_minutes = 10
+      }
+    }
+
+    dynamic "notification" {
+      for_each = local.has_emails ? [1] : []
+      content {
+        recipients {
+          emails = var.notification_emails
+        }
+        notify_on                  = "triggered_and_resolved"
+        retriggering_period_minutes = 10
+      }
+    }
+  }
+
+  type_definition {
+    logs_threshold {
+      rules {
+        condition {
+          threshold      = 50
+          time_window    = "5_minutes"
+          condition_type = "more_than"
+        }
+      }
+
+      logs_filter {
+        simple_filter {
+          lucene_query = "*"
+          label_filters {
+            application_name {
+              rule_type = "is"
+              values    = [var.application_name]
+            }
+            severities = ["error", "critical"]
+          }
+        }
+      }
+
+      notification_payload_filter = ["coralogix.metadata.subsystemName"]
+
+      undetected_values_management {
+        auto_retire_timeframe = "never"
+      }
+    }
+  }
+}
+
+# ── 3c. Service Down — Unique Count Alert ───────────────────────────────────
+#
+# Fires when the number of unique subsystems emitting logs drops below the
+# expected count (4 services) over a 10-minute window, signalling that one or
+# more services have stopped producing logs entirely.
+
+resource "coralogix_alert" "service_down" {
+  name        = "${local.resource_prefix}-service-down"
+  description = "Fewer than ${length(local.services)} services are emitting logs over 10 minutes — a service may be down"
+  severity    = "critical"
+  enabled     = true
+  labels      = local.common_labels
+
+  notification_group {
+    dynamic "notification" {
+      for_each = local.has_webhook ? [1] : []
+      content {
+        integration_id             = coralogix_webhook.alerts[0].id
+        notify_on                  = "triggered_only"
+        retriggering_period_minutes = 5
+      }
+    }
+
+    dynamic "notification" {
+      for_each = local.has_emails ? [1] : []
+      content {
+        recipients {
+          emails = var.notification_emails
+        }
+        notify_on                  = "triggered_only"
+        retriggering_period_minutes = 5
+      }
+    }
+  }
+
+  type_definition {
+    logs_unique_count {
+      rules {
+        condition {
+          unique_count_key = "coralogix.metadata.subsystemName"
+          max_unique_count = length(local.services) - 1
+          time_window      = "10_minutes"
+        }
+      }
+
+      logs_filter {
+        simple_filter {
+          lucene_query = "*"
+          label_filters {
+            application_name {
+              rule_type = "is"
+              values    = [var.application_name]
+            }
+          }
+        }
+      }
+
+      notification_payload_filter = ["coralogix.metadata.subsystemName"]
+    }
+  }
+}
+
+# ── 3d. Slow API Response — Metric Alert ────────────────────────────────────
+#
+# Fires when the p95 HTTP response time for the API subsystem exceeds 2000 ms
+# over a 5-minute evaluation window.
+
+resource "coralogix_alert" "slow_api_response" {
+  name        = "${local.resource_prefix}-slow-api-response"
+  description = "P95 API response time exceeds 2000 ms over a 5-minute window"
+  severity    = "warning"
+  enabled     = true
+  labels      = local.common_labels
+
+  notification_group {
+    dynamic "notification" {
+      for_each = local.has_webhook ? [1] : []
+      content {
+        integration_id             = coralogix_webhook.alerts[0].id
+        notify_on                  = "triggered_and_resolved"
+        retriggering_period_minutes = 15
+      }
+    }
+
+    dynamic "notification" {
+      for_each = local.has_emails ? [1] : []
+      content {
+        recipients {
+          emails = var.notification_emails
+        }
+        notify_on                  = "triggered_and_resolved"
+        retriggering_period_minutes = 15
+      }
+    }
+  }
+
+  type_definition {
+    metric_threshold {
+      metric_filter {
+        promql = "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{subsystem=\"api\"}[5m])) by (le)) * 1000"
+      }
+
+      rules {
+        condition {
+          threshold      = 2000
+          time_window    = "5_minutes"
+          condition_type = "more_than"
+          min_non_null_values_percentage = 50
+        }
+      }
+
+      notification_payload_filter = []
+
+      undetected_values_management {
+        auto_retire_timeframe = "never"
+      }
+    }
+  }
+}
+
+# ── 3e. MongoDB Connection Failure — Immediate Alert ────────────────────────
+#
+# Fires immediately on any log line containing MongoDB driver errors or TCP
+# connection refusals — no time-window aggregation.
+
+resource "coralogix_alert" "mongo_connection_failure" {
+  name        = "${local.resource_prefix}-mongo-connection-failure"
+  description = "Immediate alert on MongoDB driver errors (MongoServerError) or TCP connection refusals (ECONNREFUSED)"
+  severity    = "critical"
+  enabled     = true
+  labels      = local.common_labels
+
+  notification_group {
+    dynamic "notification" {
+      for_each = local.has_webhook ? [1] : []
+      content {
+        integration_id             = coralogix_webhook.alerts[0].id
+        notify_on                  = "triggered_only"
+        retriggering_period_minutes = 5
+      }
+    }
+
+    dynamic "notification" {
+      for_each = local.has_emails ? [1] : []
+      content {
+        recipients {
+          emails = var.notification_emails
+        }
+        notify_on                  = "triggered_only"
+        retriggering_period_minutes = 5
+      }
+    }
+  }
+
+  type_definition {
+    logs_immediate {
+      logs_filter {
+        simple_filter {
+          lucene_query = "\"MongoServerError\" OR \"ECONNREFUSED\""
+          label_filters {
+            application_name {
+              rule_type = "is"
+              values    = [var.application_name]
+            }
+            severities = ["error", "critical"]
+          }
+        }
+      }
+
+      notification_payload_filter = ["coralogix.metadata.subsystemName", "msg"]
+    }
+  }
+}
+
+# ── 3f. Auth Brute Force — Ratio Alert ──────────────────────────────────────
+#
+# Fires when the ratio of failed authentication attempts to total auth
+# requests exceeds 20 % in a 5-minute window on the API subsystem.
+
+resource "coralogix_alert" "auth_brute_force" {
+  name        = "${local.resource_prefix}-auth-brute-force"
+  description = "Failed authentication attempts exceed 20 %% of all auth requests in a 5-minute window"
+  severity    = "error"
+  enabled     = true
+  labels      = local.common_labels
+
+  notification_group {
+    dynamic "notification" {
+      for_each = local.has_webhook ? [1] : []
+      content {
+        integration_id             = coralogix_webhook.alerts[0].id
+        notify_on                  = "triggered_only"
+        retriggering_period_minutes = 10
+      }
+    }
+
+    dynamic "notification" {
+      for_each = local.has_emails ? [1] : []
+      content {
+        recipients {
+          emails = var.notification_emails
+        }
+        notify_on                  = "triggered_only"
+        retriggering_period_minutes = 10
+      }
+    }
+  }
+
+  type_definition {
+    logs_ratio_threshold {
+      numerator_alias   = "failed_auth_attempts"
+      denominator_alias = "all_auth_requests"
+
+      rules {
+        condition {
+          threshold      = 20
+          time_window    = "5_minutes"
+          condition_type = "more_than"
+        }
+      }
+
+      numerator {
+        simple_filter {
+          lucene_query = "(status:401 OR status:403) AND (path:\"/api/auth/*\" OR path:\"/api/login\")"
+          label_filters {
+            application_name {
+              rule_type = "is"
+              values    = [var.application_name]
+            }
+            subsystem_name {
+              rule_type = "is"
+              values    = ["api"]
+            }
+          }
+        }
+      }
+
+      denominator {
+        simple_filter {
+          lucene_query = "path:\"/api/auth/*\" OR path:\"/api/login\""
+          label_filters {
+            application_name {
+              rule_type = "is"
+              values    = [var.application_name]
+            }
+            subsystem_name {
+              rule_type = "is"
+              values    = ["api"]
+            }
+          }
+        }
+      }
+
+      notification_payload_filter = ["coralogix.metadata.subsystemName", "path", "status"]
+    }
+  }
+}
+
+# ── 3g. Memory Pressure — Metric Alert ──────────────────────────────────────
+#
+# Fires when container memory utilisation exceeds 85 % for a sustained
+# 5-minute window.
+
+resource "coralogix_alert" "memory_pressure" {
+  name        = "${local.resource_prefix}-memory-pressure"
+  description = "Container memory utilisation exceeds 85 %% for 5 minutes"
+  severity    = "warning"
+  enabled     = true
+  labels      = local.common_labels
+
+  notification_group {
+    group_by_fields = ["container_name"]
+
+    dynamic "notification" {
+      for_each = local.has_webhook ? [1] : []
+      content {
+        integration_id             = coralogix_webhook.alerts[0].id
+        notify_on                  = "triggered_and_resolved"
+        retriggering_period_minutes = 15
+      }
+    }
+
+    dynamic "notification" {
+      for_each = local.has_emails ? [1] : []
+      content {
+        recipients {
+          emails = var.notification_emails
+        }
+        notify_on                  = "triggered_and_resolved"
+        retriggering_period_minutes = 15
+      }
+    }
+  }
+
+  type_definition {
+    metric_threshold {
+      metric_filter {
+        promql = "max by (container_name) (container_memory_usage_bytes / container_spec_memory_limit_bytes) * 100"
+      }
+
+      rules {
+        condition {
+          threshold      = 85
+          time_window    = "5_minutes"
+          condition_type = "more_than"
+          min_non_null_values_percentage = 80
+        }
+      }
+
+      notification_payload_filter = []
+
+      undetected_values_management {
+        auto_retire_timeframe = "never"
+      }
+    }
+  }
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 4. PARSING RULES
+#
+# Rule groups that structure raw log text into queryable fields before
+# indexing.  Organised as separate groups so individual pipelines can be
+# toggled independently.
+# ═════════════════════════════════════════════════════════════════════════════
+
+# ── 4a. JSON Auto-Parse ─────────────────────────────────────────────────────
+
+resource "coralogix_rules_group" "json_parsing" {
+  name        = "${local.resource_prefix}-json-auto-parse"
+  description = "Automatically extract JSON fields from structured log bodies across all WealthWise services"
+  enabled     = true
+  creator     = "terraform"
+  order       = 1
+
+  rule_subgroups {
+    rules {
+      name         = "Parse JSON log body"
+      description  = "Extract all top-level keys from the JSON log payload into searchable fields"
+      enabled      = true
+      source_field = "text"
+
+      parse_json_field {
+        destination_field      = "json"
+        keep_source_field      = true
+        keep_destination_field = true
+      }
+    }
+  }
+}
+
+# ── 4b. Severity Extraction ─────────────────────────────────────────────────
+
+resource "coralogix_rules_group" "severity_extraction" {
+  name        = "${local.resource_prefix}-severity-extraction"
+  description = "Map the application-level 'level' field to Coralogix severity metadata"
+  enabled     = true
+  creator     = "terraform"
+  order       = 2
+
+  rule_subgroups {
+    rules {
+      name         = "Extract severity from level field"
+      description  = "Capture the value of json.level (e.g. error, warn, info, debug) as the log severity"
+      enabled      = true
+      source_field = "json.level"
+
+      extract {
+        regular_expression = "^(?P<severity>.+)$"
+      }
+    }
+  }
+}
+
+# ── 4c. Timestamp Extraction ────────────────────────────────────────────────
+
+resource "coralogix_rules_group" "timestamp_extraction" {
+  name        = "${local.resource_prefix}-timestamp-extraction"
+  description = "Extract the application-emitted timestamp so Coralogix uses it for ordering rather than ingestion time"
+  enabled     = true
+  creator     = "terraform"
+  order       = 3
+
+  rule_subgroups {
+    rules {
+      name         = "Extract ISO-8601 timestamp"
+      description  = "Parse json.timestamp into the Coralogix event timestamp"
+      enabled      = true
+      source_field = "json.timestamp"
+
+      extract {
+        regular_expression = "^(?P<timestamp>.+)$"
+      }
+    }
+  }
+}
+
+# ── 4d. Subsystem Extraction from Kubernetes Labels ─────────────────────────
+
+resource "coralogix_rules_group" "subsystem_extraction" {
+  name        = "${local.resource_prefix}-subsystem-extraction"
+  description = "Derive the Coralogix subsystem name from Kubernetes pod labels (app.kubernetes.io/name)"
+  enabled     = true
+  creator     = "terraform"
+  order       = 4
+
+  rule_subgroups {
+    rules {
+      name         = "Extract subsystem from k8s app label"
+      description  = "Use the Kubernetes app.kubernetes.io/name label as the Coralogix subsystem identifier"
+      enabled      = true
+      source_field = "json.kubernetes.labels.app_kubernetes_io_name"
+
+      extract {
+        regular_expression = "^(?P<subsystemName>.+)$"
+      }
+    }
+  }
+
+  rule_subgroups {
+    rules {
+      name         = "Fallback: extract subsystem from container name"
+      description  = "If the Kubernetes app label is absent, fall back to the container name for subsystem identification"
+      enabled      = true
+      source_field = "json.kubernetes.container_name"
+
+      extract {
+        regular_expression = "^(?P<subsystemName>.+)$"
+      }
+    }
+  }
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 5. DASHBOARD
+#
+# Single-pane overview covering service health, latency distribution, log
+# volume, database performance, and authentication activity.
+# ═════════════════════════════════════════════════════════════════════════════
+
+resource "coralogix_dashboard" "wealthwise" {
+  name        = "${local.resource_prefix}-service-overview"
+  description = "WealthWise ${var.environment} — unified service health, latency, log volume, MongoDB, and auth overview"
+
+  layout {
+    # ── Section 1: Service Health Overview ──────────────────────────────────
+    sections {
+      id {
+        value = "${local.resource_prefix}-health-overview"
+      }
+
+      rows {
+        id {
+          value = "${local.resource_prefix}-health-row-errors-per-service"
+        }
+        height = 19
+
+        widgets {
+          id {
+            value = "${local.resource_prefix}-widget-error-rate-timeseries"
+          }
+          title       = "Error Rate by Service"
+          description = "Error-severity log count per service over time"
+          definition {
+            line_chart {
+              legend {
+                is_visible   = true
+                columns      = ["avg", "max", "last"]
+                group_by_query = true
+              }
+              tooltip {
+                show_labels = true
+                type        = "all"
+              }
+              query_definitions {
+                id           = "${local.resource_prefix}-q-error-rate"
+                name         = "Errors / 5m"
+                color_scheme = "classic"
+                is_visible   = true
+
+                query {
+                  logs {
+                    lucene_query = "*"
+                    group_by     = ["coralogix.metadata.subsystemName"]
+                    aggregations {
+                      type = "count"
+                    }
+                    filters {
+                      field = "coralogix.metadata.applicationName"
+                      operator {
+                        type            = "equals"
+                        selected_values = [var.application_name]
+                      }
+                    }
+                    filters {
+                      field = "coralogix.metadata.severity"
+                      operator {
+                        type            = "equals"
+                        selected_values = ["error", "critical"]
+                      }
+                    }
+                  }
+                }
+
+                resolution {
+                  buckets_presented = 120
+                }
+              }
+            }
+          }
+        }
+
+        widgets {
+          id {
+            value = "${local.resource_prefix}-widget-5xx-counter"
+          }
+          title       = "HTTP 5xx Count (API)"
+          description = "Total 5xx responses from the API subsystem"
+          definition {
+            line_chart {
+              legend {
+                is_visible = true
+              }
+              tooltip {
+                show_labels = true
+                type        = "all"
+              }
+              query_definitions {
+                id           = "${local.resource_prefix}-q-5xx"
+                name         = "5xx Count"
+                color_scheme = "classic"
+                is_visible   = true
+
+                query {
+                  logs {
+                    lucene_query = "status:[500 TO 599]"
+                    aggregations {
+                      type = "count"
+                    }
+                    filters {
+                      field = "coralogix.metadata.subsystemName"
+                      operator {
+                        type            = "equals"
+                        selected_values = ["api"]
+                      }
+                    }
+                  }
+                }
+
+                resolution {
+                  buckets_presented = 120
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    # ── Section 2: Request Latency ─────────────────────────────────────────
+    sections {
+      id {
+        value = "${local.resource_prefix}-latency"
+      }
+
+      rows {
+        id {
+          value = "${local.resource_prefix}-latency-row-percentiles"
+        }
+        height = 22
+
+        widgets {
+          id {
+            value = "${local.resource_prefix}-widget-latency-p50"
+          }
+          title       = "API Latency — p50"
+          description = "Median request duration for the API service"
+          definition {
+            line_chart {
+              legend {
+                is_visible = true
+              }
+              tooltip {
+                show_labels = true
+                type        = "all"
+              }
+              query_definitions {
+                id           = "${local.resource_prefix}-q-p50"
+                name         = "p50 (ms)"
+                color_scheme = "classic"
+                is_visible   = true
+
+                query {
+                  metrics {
+                    promql_query = "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{subsystem=\"api\"}[5m])) by (le)) * 1000"
+                  }
+                }
+
+                resolution {
+                  buckets_presented = 120
+                }
+              }
+            }
+          }
+        }
+
+        widgets {
+          id {
+            value = "${local.resource_prefix}-widget-latency-p95"
+          }
+          title       = "API Latency — p95"
+          description = "95th-percentile request duration for the API service"
+          definition {
+            line_chart {
+              legend {
+                is_visible = true
+              }
+              tooltip {
+                show_labels = true
+                type        = "all"
+              }
+              query_definitions {
+                id           = "${local.resource_prefix}-q-p95"
+                name         = "p95 (ms)"
+                color_scheme = "classic"
+                is_visible   = true
+
+                query {
+                  metrics {
+                    promql_query = "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{subsystem=\"api\"}[5m])) by (le)) * 1000"
+                  }
+                }
+
+                resolution {
+                  buckets_presented = 120
+                }
+              }
+            }
+          }
+        }
+
+        widgets {
+          id {
+            value = "${local.resource_prefix}-widget-latency-p99"
+          }
+          title       = "API Latency — p99"
+          description = "99th-percentile request duration for the API service"
+          definition {
+            line_chart {
+              legend {
+                is_visible = true
+              }
+              tooltip {
+                show_labels = true
+                type        = "all"
+              }
+              query_definitions {
+                id           = "${local.resource_prefix}-q-p99"
+                name         = "p99 (ms)"
+                color_scheme = "classic"
+                is_visible   = true
+
+                query {
+                  metrics {
+                    promql_query = "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{subsystem=\"api\"}[5m])) by (le)) * 1000"
+                  }
+                }
+
+                resolution {
+                  buckets_presented = 120
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    # ── Section 3: Log Volume by Severity ──────────────────────────────────
+    sections {
+      id {
+        value = "${local.resource_prefix}-log-volume"
+      }
+
+      rows {
+        id {
+          value = "${local.resource_prefix}-log-volume-row"
+        }
+        height = 19
+
+        widgets {
+          id {
+            value = "${local.resource_prefix}-widget-log-volume-severity"
+          }
+          title       = "Log Volume by Severity"
+          description = "Log count grouped by severity level across all services"
+          definition {
+            line_chart {
+              legend {
+                is_visible   = true
+                columns      = ["avg", "sum", "last"]
+                group_by_query = true
+              }
+              tooltip {
+                show_labels = true
+                type        = "all"
+              }
+              query_definitions {
+                id           = "${local.resource_prefix}-q-log-vol-severity"
+                name         = "Logs / 5m"
+                color_scheme = "severity"
+                is_visible   = true
+
+                query {
+                  logs {
+                    lucene_query = "*"
+                    group_by     = ["coralogix.metadata.severity"]
+                    aggregations {
+                      type = "count"
+                    }
+                    filters {
+                      field = "coralogix.metadata.applicationName"
+                      operator {
+                        type            = "equals"
+                        selected_values = [var.application_name]
+                      }
+                    }
+                  }
+                }
+
+                resolution {
+                  buckets_presented = 120
+                }
+              }
+            }
+          }
+        }
+
+        widgets {
+          id {
+            value = "${local.resource_prefix}-widget-log-volume-service"
+          }
+          title       = "Log Volume by Service"
+          description = "Log count grouped by subsystem to identify noisy services"
+          definition {
+            line_chart {
+              legend {
+                is_visible   = true
+                group_by_query = true
+              }
+              tooltip {
+                show_labels = true
+                type        = "all"
+              }
+              query_definitions {
+                id           = "${local.resource_prefix}-q-log-vol-service"
+                name         = "Logs / 5m"
+                color_scheme = "classic"
+                is_visible   = true
+
+                query {
+                  logs {
+                    lucene_query = "*"
+                    group_by     = ["coralogix.metadata.subsystemName"]
+                    aggregations {
+                      type = "count"
+                    }
+                    filters {
+                      field = "coralogix.metadata.applicationName"
+                      operator {
+                        type            = "equals"
+                        selected_values = [var.application_name]
+                      }
+                    }
+                  }
+                }
+
+                resolution {
+                  buckets_presented = 120
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    # ── Section 4: MongoDB Performance ─────────────────────────────────────
+    sections {
+      id {
+        value = "${local.resource_prefix}-mongodb"
+      }
+
+      rows {
+        id {
+          value = "${local.resource_prefix}-mongodb-row"
+        }
+        height = 19
+
+        widgets {
+          id {
+            value = "${local.resource_prefix}-widget-mongo-errors"
+          }
+          title       = "MongoDB Errors"
+          description = "MongoServerError and connection refusal logs over time"
+          definition {
+            line_chart {
+              legend {
+                is_visible = true
+              }
+              tooltip {
+                show_labels = true
+                type        = "all"
+              }
+              query_definitions {
+                id           = "${local.resource_prefix}-q-mongo-err"
+                name         = "Mongo Errors"
+                color_scheme = "classic"
+                is_visible   = true
+
+                query {
+                  logs {
+                    lucene_query = "\"MongoServerError\" OR \"ECONNREFUSED\" OR \"MongoNetworkError\""
+                    aggregations {
+                      type = "count"
+                    }
+                    filters {
+                      field = "coralogix.metadata.applicationName"
+                      operator {
+                        type            = "equals"
+                        selected_values = [var.application_name]
+                      }
+                    }
+                  }
+                }
+
+                resolution {
+                  buckets_presented = 120
+                }
+              }
+            }
+          }
+        }
+
+        widgets {
+          id {
+            value = "${local.resource_prefix}-widget-mongo-latency"
+          }
+          title       = "MongoDB Query Latency"
+          description = "Average MongoDB operation duration reported by the application"
+          definition {
+            line_chart {
+              legend {
+                is_visible = true
+              }
+              tooltip {
+                show_labels = true
+                type        = "all"
+              }
+              query_definitions {
+                id           = "${local.resource_prefix}-q-mongo-latency"
+                name         = "Avg Duration (ms)"
+                color_scheme = "classic"
+                is_visible   = true
+
+                query {
+                  metrics {
+                    promql_query = "avg(rate(mongodb_operation_duration_seconds_sum[5m]) / rate(mongodb_operation_duration_seconds_count[5m])) * 1000"
+                  }
+                }
+
+                resolution {
+                  buckets_presented = 120
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    # ── Section 5: Authentication Events ───────────────────────────────────
+    sections {
+      id {
+        value = "${local.resource_prefix}-auth"
+      }
+
+      rows {
+        id {
+          value = "${local.resource_prefix}-auth-row"
+        }
+        height = 19
+
+        widgets {
+          id {
+            value = "${local.resource_prefix}-widget-auth-success-fail"
+          }
+          title       = "Authentication Outcomes"
+          description = "Successful vs. failed login and auth requests on the API"
+          definition {
+            line_chart {
+              legend {
+                is_visible   = true
+                group_by_query = true
+              }
+              tooltip {
+                show_labels = true
+                type        = "all"
+              }
+              query_definitions {
+                id           = "${local.resource_prefix}-q-auth-success"
+                name         = "Successful Auth"
+                color_scheme = "classic"
+                is_visible   = true
+
+                query {
+                  logs {
+                    lucene_query = "(path:\"/api/auth/*\" OR path:\"/api/login\") AND status:[200 TO 299]"
+                    aggregations {
+                      type = "count"
+                    }
+                    filters {
+                      field = "coralogix.metadata.subsystemName"
+                      operator {
+                        type            = "equals"
+                        selected_values = ["api"]
+                      }
+                    }
+                  }
+                }
+
+                resolution {
+                  buckets_presented = 120
+                }
+              }
+
+              query_definitions {
+                id           = "${local.resource_prefix}-q-auth-fail"
+                name         = "Failed Auth"
+                color_scheme = "classic"
+                is_visible   = true
+
+                query {
+                  logs {
+                    lucene_query = "(path:\"/api/auth/*\" OR path:\"/api/login\") AND (status:401 OR status:403)"
+                    aggregations {
+                      type = "count"
+                    }
+                    filters {
+                      field = "coralogix.metadata.subsystemName"
+                      operator {
+                        type            = "equals"
+                        selected_values = ["api"]
+                      }
+                    }
+                  }
+                }
+
+                resolution {
+                  buckets_presented = 120
+                }
+              }
+            }
+          }
+        }
+
+        widgets {
+          id {
+            value = "${local.resource_prefix}-widget-auth-failure-rate"
+          }
+          title       = "Auth Failure Ratio"
+          description = "Percentage of authentication requests that result in 401/403 responses"
+          definition {
+            gauge {
+              min   = 0
+              max   = 100
+              unit  = "percent"
+
+              query {
+                metrics {
+                  promql_query = "sum(rate(http_requests_total{path=~\"/api/auth/.*|/api/login\",status=~\"401|403\",subsystem=\"api\"}[10m])) / sum(rate(http_requests_total{path=~\"/api/auth/.*|/api/login\",subsystem=\"api\"}[10m])) * 100"
+                }
+              }
+
+              thresholds {
+                color = "#22c55e"
+                value = 0
+              }
+              thresholds {
+                color = "#f59e0b"
+                value = 10
+              }
+              thresholds {
+                color = "#ef4444"
+                value = 25
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  filters {
+    source {
+      logs {
+        observation_field {
+          keypath = ["coralogix.metadata.applicationName"]
+          scope   = "metadata"
+        }
+        operator {
+          type            = "equals"
+          selected_values = [var.application_name]
+        }
+      }
+    }
+  }
+
+  time_frame {
+    relative {
+      duration = "24h"
+    }
+  }
+}

--- a/terraform/modules/coralogix/outputs.tf
+++ b/terraform/modules/coralogix/outputs.tf
@@ -1,0 +1,46 @@
+# -----------------------------------------------------------------------------
+# Coralogix Module — Outputs
+# WealthWise Finance Tracker
+# -----------------------------------------------------------------------------
+
+output "tco_policy_ids" {
+  description = "Map of TCO policy tier name to Coralogix policy ID"
+  value = {
+    high   = coralogix_tco_policy_logs.high_priority.id
+    medium = coralogix_tco_policy_logs.medium_priority.id
+    low    = coralogix_tco_policy_logs.low_priority.id
+  }
+}
+
+output "alert_ids" {
+  description = "Map of alert descriptive name to Coralogix alert ID"
+  value = {
+    api_5xx_spike       = coralogix_alert.api_5xx_spike.id
+    high_error_rate     = coralogix_alert.high_error_rate.id
+    service_down        = coralogix_alert.service_down.id
+    slow_api_response   = coralogix_alert.slow_api_response.id
+    mongo_conn_failure  = coralogix_alert.mongo_connection_failure.id
+    auth_brute_force    = coralogix_alert.auth_brute_force.id
+    memory_pressure     = coralogix_alert.memory_pressure.id
+  }
+}
+
+output "dashboard_id" {
+  description = "Coralogix dashboard ID for the WealthWise service overview"
+  value       = coralogix_dashboard.wealthwise.id
+}
+
+output "parsing_rule_ids" {
+  description = "List of Coralogix parsing rule group IDs"
+  value = [
+    coralogix_rules_group.json_parsing.id,
+    coralogix_rules_group.severity_extraction.id,
+    coralogix_rules_group.timestamp_extraction.id,
+    coralogix_rules_group.subsystem_extraction.id,
+  ]
+}
+
+output "webhook_id" {
+  description = "Coralogix webhook integration ID (empty string when no webhook URL is configured)"
+  value       = local.has_webhook ? coralogix_webhook.alerts[0].id : ""
+}

--- a/terraform/modules/coralogix/variables.tf
+++ b/terraform/modules/coralogix/variables.tf
@@ -1,0 +1,96 @@
+# -----------------------------------------------------------------------------
+# Coralogix Module — Input Variables
+# WealthWise Finance Tracker
+# -----------------------------------------------------------------------------
+
+# ── Provider Authentication ──────────────────────────────────────────────────
+
+variable "coralogix_api_key" {
+  description = "Coralogix Alerts, Rules & Tags API key used for provider authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "coralogix_domain" {
+  description = "Coralogix domain endpoint matching your account region (coralogix.com, coralogix.us, eu2.coralogix.com, coralogix.in, coralogix.sg)"
+  type        = string
+  default     = "coralogix.us"
+
+  validation {
+    condition = contains([
+      "coralogix.com",
+      "coralogix.us",
+      "eu2.coralogix.com",
+      "coralogix.in",
+      "coralogix.sg",
+    ], var.coralogix_domain)
+    error_message = "coralogix_domain must be one of: coralogix.com, coralogix.us, eu2.coralogix.com, coralogix.in, coralogix.sg."
+  }
+}
+
+# ── Resource Identification ──────────────────────────────────────────────────
+
+variable "environment" {
+  description = "Deployment environment name (e.g. production, staging, dev)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,30}$", var.environment))
+    error_message = "environment must be lowercase alphanumeric with hyphens, 2-31 characters, starting with a letter."
+  }
+}
+
+variable "project_name" {
+  description = "Project identifier used as a prefix for all Coralogix resource names"
+  type        = string
+  default     = "wealthwise"
+}
+
+variable "application_name" {
+  description = "Coralogix application name used for log filtering and TCO policy scoping"
+  type        = string
+  default     = "wealthwise"
+}
+
+# ── Notification Targets ─────────────────────────────────────────────────────
+
+variable "notification_emails" {
+  description = "List of email addresses that receive alert notifications"
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = alltrue([for e in var.notification_emails : can(regex("^[^@]+@[^@]+\\.[^@]+$", e))])
+    error_message = "All notification_emails entries must be valid email addresses."
+  }
+}
+
+variable "alert_webhook_url" {
+  description = "Webhook URL for alert delivery (Slack, PagerDuty, custom endpoint, etc.)"
+  type        = string
+  default     = ""
+}
+
+# ── TCO Quota Configuration ─────────────────────────────────────────────────
+
+variable "logs_critical_daily_quota_gb" {
+  description = "Daily ingestion quota in GB for high-priority logs (ERROR/CRITICAL from API)"
+  type        = number
+  default     = 5
+
+  validation {
+    condition     = var.logs_critical_daily_quota_gb > 0 && var.logs_critical_daily_quota_gb <= 100
+    error_message = "logs_critical_daily_quota_gb must be between 1 and 100."
+  }
+}
+
+variable "logs_normal_daily_quota_gb" {
+  description = "Daily ingestion quota in GB for medium-priority logs (WARN/INFO across all services)"
+  type        = number
+  default     = 20
+
+  validation {
+    condition     = var.logs_normal_daily_quota_gb > 0 && var.logs_normal_daily_quota_gb <= 500
+    error_message = "logs_normal_daily_quota_gb must be between 1 and 500."
+  }
+}

--- a/terraform/modules/coralogix/versions.tf
+++ b/terraform/modules/coralogix/versions.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.5"
 
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
     coralogix = {
       source  = "coralogix/coralogix"
       version = "~> 2.0"


### PR DESCRIPTION
Integrate Coralogix for centralized logs, metrics, and traces via OpenTelemetry Collector across Kubernetes (Helm + Kustomize), Docker Compose, and Terraform.

Helm chart:
- OTEL Collector DaemonSet with filelog, Prometheus, kubeletstats receivers
- Coralogix Secret, ConfigMap, egress NetworkPolicy
- Per-environment values (dev disabled, staging reduced, prod full)

Kustomize:
- OTEL Collector DaemonSet, Service, RBAC, ConfigMap
- Coralogix Secret template, ingress/egress NetworkPolicies
- Production overlay with increased resource limits

Docker Compose (production):
- Fluent Bit log shipper with Coralogix HTTP output
- OTEL Collector for Docker container metrics and traces
- All app services switched to fluentd logging driver
- Lua-based subsystem routing per container name

Terraform:
- New coralogix module with 16 resources via coralogix/coralogix provider
- 7 alert rules (5xx spike, error rate, service down, slow API, MongoDB failure, auth brute force, memory pressure)
- 3 TCO log tiering policies, 4 parsing rule groups
- Comprehensive 5-section dashboard
- Wired into production environment

Nginx:
- Structured JSON access log format (json_combined) for auto-parsing